### PR TITLE
Adaptation to Qt's pimpl idiom design. Improved inheritance safety.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,12 @@ The SingleApplication class implements a `showUp()` signal. You can bind to that
 Note that since `SingleApplication` extends the `QApplication` class  you can do the following:
 ```cpp
 // Truly raise your window.
-QObject::connect(&app, &SingleApplication::showUp, [&]{
-        window.show();
-        window.raise();
-        window.activateWindow();
-    }); // 'window' is your QWindow instance
+QObject::connect(&app, &SingleApplication::showUp, [&]
+{
+    window.show();
+    window.raise();
+    window.activateWindow();
+}); // 'window' is your QWindow instance
 ```
 
 Using `QApplication::instance()` is a neat way to get the `SingleApplication` instance at any place in your program.

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@ SingleApplication
 
 This is a replacement of the QSingleApplication for `Qt5`.
 
-Keeps the Primary Instance of your Application and kills each subsequent instance.
+Keeps the Primary Instance of your Application and kills each subsequent instances.
 
 Usage
 -----
-The `SingleApplication` class inherits from `QApplication`. Use it as if you are using the `QApplication` class.
+The `SingleApplication` class inherits from whatever `Q[Core|Gui]Application` class you specify in the `*.pro` file. Further usage is similar to use one of the `Q[Core|Gui]Application` classes.
 
 The library uses your `Organization Name` and `Application Name` to set up a `QLocalServer` and a `QSharedMemory` block. The first instance of your Application would check if the shared memory block exists and if not it will start a `QLocalServer` and then listen for connections on it. Each subsequent instance of your application would check if the shared memory block exists and if it does, it will connect to the QLocalServer to notify it that a new instance had been started, after which would terminate the new instance with status code `0`. The Primary Instance, `SingleApplication` would emmit the `showUp()` signal upon detecting that a new instance had been started.
 
@@ -15,6 +15,10 @@ The library uses `stdlib` to terminate the program with the `exit()` function.
 
 Here is an example usage of the library:
 ```cpp
+// project.pro
+DEFINES += QAPPLICATION_CLASS=QApplication # or whatever app class you want
+
+// main.cpp
 #include "singleapplication.h"
 
 int main(int argc, char *argv[])
@@ -34,21 +38,16 @@ The SingleApplication class implements a `showUp()` signal. You can bind to that
 
 Note that since `SingleApplication` extends the `QApplication` class  you can do the following:
 ```cpp
-QObject::connect(QApplication::instance(), SIGNAL(showUp()), window, SLOT(raise())); // window is your QWindow instance
+// Truly raise your window.
+QObject::connect(&app, &SingleApplication::showUp, [&]{
+        window.show();
+        window.raise();
+        window.activateWindow();
+    }); // 'window' is your QWindow instance
 ```
 
 Using `QApplication::instance()` is a neat way to get the `SingleApplication` instance at any place in your program.
 
-Extending from other application classes
------------------------
-
-`SingleApplication` extends from the `QApplication` class by default , but you can easily change that to `QGuiApplication` or `QCoreApplication` with the `QAPPLICATION_CLASS` macro. Define it before the include statement of `singleapplication.h` or change the default value in the file.
-
-__Example:__
-
-```cpp
-#define QAPPLICATION_CLASS QCoreApplication
-```
 
 Implementation
 --------------

--- a/singleapplication.cpp
+++ b/singleapplication.cpp
@@ -115,7 +115,7 @@ SingleApplication::SingleApplication(int &argc, char *argv[])
         // terminated.
         if( d->socket->waitForConnected(100) )
         {
-            // Terminate the program using STDLib's exit function.
+            // Terminate the program using STDLib's exit function
             ::exit(EXIT_SUCCESS);
         } else {
             delete d->memory;

--- a/singleapplication.cpp
+++ b/singleapplication.cpp
@@ -1,16 +1,21 @@
-#include "singleapplication.h"
+#include <cstdlib>
+
 #include <QSharedMemory>
 #include <QLocalSocket>
 #include <QLocalServer>
 #include <QMutex>
-#include <cstdlib>
 
 #ifdef Q_OS_UNIX
     #include <signal.h>
     #include <unistd.h>
 #endif
 
+#include "singleapplication.h"
+
+
 class SingleApplicationPrivate {
+    Q_DECLARE_PUBLIC(SingleApplication)
+
 public:
     SingleApplicationPrivate(SingleApplication *q_ptr) : q_ptr(q_ptr) { }
 
@@ -18,7 +23,7 @@ public:
     {
         // Start a QLocalServer to listen for connections
         server = new QLocalServer();
-        server->removeServer(serverName);
+        QLocalServer::removeServer(serverName);
         server->listen(serverName);
         QObject::connect(server, SIGNAL(newConnection()), q_ptr, SLOT(slotConnectionEstablished()));
     }
@@ -27,8 +32,8 @@ public:
     void crashHandler()
     {
         // This guarantees the program will work even with multiple
-        // instances of SingleApplication in different threads
-        // Which in my opinion is idiotic, but lets handle that too
+        // instances of SingleApplication in different threads.
+        // Which in my opinion is idiotic, but lets handle that too.
         {
             sharedMemMutex.lock();
             sharedMem.append(memory);
@@ -38,9 +43,9 @@ public:
         // QSharedMemory block is deleted even if the process crashes
         signal(SIGSEGV, SingleApplicationPrivate::terminate);
         signal(SIGABRT, SingleApplicationPrivate::terminate);
-        signal(SIGFPE, SingleApplicationPrivate::terminate);
-        signal(SIGILL, SingleApplicationPrivate::terminate);
-        signal(SIGINT, SingleApplicationPrivate::terminate);
+        signal(SIGFPE,  SingleApplicationPrivate::terminate);
+        signal(SIGILL,  SingleApplicationPrivate::terminate);
+        signal(SIGINT,  SingleApplicationPrivate::terminate);
         signal(SIGTERM, SingleApplicationPrivate::terminate);
     }
 
@@ -75,38 +80,43 @@ public:
  * @param argv
  */
 SingleApplication::SingleApplication(int &argc, char *argv[])
-    : QAPPLICATION_CLASS(argc, argv), d_ptr(new SingleApplicationPrivate(this))
+    : app_t(argc, argv), d_ptr(new SingleApplicationPrivate(this))
 {
-    QString serverName = QAPPLICATION_CLASS::organizationName() + QAPPLICATION_CLASS::applicationName();
+    Q_D(SingleApplication);
+
+    QString serverName = app_t::organizationName() + app_t::applicationName();
     serverName.replace(QRegExp("[^\\w\\-. ]"), "");
 
-    // Garantee thread safe behaviour with a shared memory block
-    d_ptr->memory = new QSharedMemory(serverName);
+    // Guarantee thread safe behaviour with a shared memory block
+    d->memory = new QSharedMemory(serverName);
 
     // Create a shared memory block with a minimum size of 1 byte
-    if( d_ptr->memory->create(1, QSharedMemory::ReadOnly) )
+    if( d->memory->create(1, QSharedMemory::ReadOnly) )
     {
 #ifdef Q_OS_UNIX
         // Handle any further termination signals to ensure the
         // QSharedMemory block is deleted even if the process crashes
-        d_ptr->crashHandler();
+        d->crashHandler();
 #endif
         // Successful creation means that no main process exists
         // So we start a Local Server to listen for connections
-        d_ptr->startServer(serverName);
+        d->startServer(serverName);
     } else {
         // Connect to the Local Server of the main process to notify it
         // that a new process had been started
-        d_ptr->socket = new QLocalSocket();
-        d_ptr->socket->connectToServer(serverName);
+        d->socket = new QLocalSocket();
+        d->socket->connectToServer(serverName);
 
-        // Even though a shared memory block exists, the original application might have crashed
-        // So only after a successful connection is the second instance terminated
-        if( d_ptr->socket->waitForConnected(100) )
+        // Even though a shared memory block exists, the original application
+        // might have crashed.
+        // So only after a successful connection is the second instance
+        // terminated.
+        if( d->socket->waitForConnected(100) )
         {
-            ::exit(EXIT_SUCCESS); // Terminate the program using STDLib's exit function
+            // Terminate the program using STDLib's exit function.
+            ::exit(EXIT_SUCCESS);
         } else {
-            delete d_ptr->memory;
+            delete d->memory;
             ::exit(EXIT_SUCCESS);
         }
     }
@@ -117,8 +127,10 @@ SingleApplication::SingleApplication(int &argc, char *argv[])
  */
 SingleApplication::~SingleApplication()
 {
-    delete d_ptr->memory;
-    d_ptr->server->close();
+    Q_D(SingleApplication);
+
+    delete d->memory;
+    d->server->close();
 }
 
 /**
@@ -126,8 +138,10 @@ SingleApplication::~SingleApplication()
  */
 void SingleApplication::slotConnectionEstablished()
 {
-    QLocalSocket *socket = d_ptr->server->nextPendingConnection();
+    Q_D(SingleApplication);
+
+    QLocalSocket *socket = d->server->nextPendingConnection();
     socket->close();
     delete socket;
-    emit showUp();
+    Q_EMIT showUp();
 }

--- a/singleapplication.cpp
+++ b/singleapplication.cpp
@@ -1,9 +1,9 @@
 #include <cstdlib>
 
-#include <QSharedMemory>
-#include <QLocalSocket>
-#include <QLocalServer>
-#include <QMutex>
+#include <QtCore/QSharedMemory>
+#include <QtCore/QMutex>
+#include <QtNetwork/QLocalSocket>
+#include <QtNetwork/QLocalServer>
 
 #ifdef Q_OS_UNIX
     #include <signal.h>

--- a/singleapplication.cpp
+++ b/singleapplication.cpp
@@ -21,11 +21,13 @@ public:
 
     void startServer(QString &serverName)
     {
+        Q_Q(SingleApplication);
+
         // Start a QLocalServer to listen for connections
         server = new QLocalServer();
         QLocalServer::removeServer(serverName);
         server->listen(serverName);
-        QObject::connect(server, SIGNAL(newConnection()), q_ptr, SLOT(slotConnectionEstablished()));
+        QObject::connect(server, SIGNAL(newConnection()), q, SLOT(slotConnectionEstablished()));
     }
 
 #ifdef Q_OS_UNIX

--- a/singleapplication.h
+++ b/singleapplication.h
@@ -1,14 +1,8 @@
 #ifndef SINGLE_APPLICATION_H
 #define SINGLE_APPLICATION_H
+#include <QtCore/QtGlobal>
 
-// Change this to inherit from QGuiApplication or QCoreApplication
-#ifndef QAPPLICATION_CLASS
-  #define QAPPLICATION_CLASS QCoreApplication
-#endif
-
-#define  QUOTE(C) #C
-#define  INCLUDE_FILE(C) QUOTE(C)
-#include INCLUDE_FILE(QAPPLICATION_CLASS)
+#include QT_STRINGIFY(QAPPLICATION_CLASS)
 
 class SingleApplicationPrivate;
 
@@ -18,19 +12,25 @@ class SingleApplicationPrivate;
  */
 class SingleApplication : public QAPPLICATION_CLASS
 {
-  Q_OBJECT
+    Q_OBJECT
+    Q_DECLARE_PRIVATE(SingleApplication)
+
+    typedef QAPPLICATION_CLASS app_t;
+
 public:
-  explicit SingleApplication(int&, char *[]);
-  ~SingleApplication();
+    explicit SingleApplication(int&, char *[]);
+    ~SingleApplication();
 
-signals:
-  void showUp();
+Q_SIGNALS:
+    void showUp();
 
-private slots:
-  void slotConnectionEstablished();
+private Q_SLOTS:
+    void slotConnectionEstablished();
 
 private:
-  SingleApplicationPrivate *d_ptr;
+    SingleApplicationPrivate *d_ptr;
+
+
 };
 
 #endif // SINGLE_APPLICATION_H

--- a/singleapplication.h
+++ b/singleapplication.h
@@ -2,6 +2,10 @@
 #define SINGLE_APPLICATION_H
 #include <QtCore/QtGlobal>
 
+#ifndef QAPPLICATION_CLASS
+  #define QAPPLICATION_CLASS QApplication
+#endif
+
 #include QT_STRINGIFY(QAPPLICATION_CLASS)
 
 class SingleApplicationPrivate;


### PR DESCRIPTION
Details:
* Improved unsafe C-style macros inheritance approach to the project-wide
DEFINES: it is unspecified in
which order source files are being preprocessed ones, so in
singleapplication.cpp the class might be inherent of default-specified
base, while in main.cpp this can be a user-provided QAPPLICATION_CLASS
definition.

* Replace Qt's pseudo-keywords to more library-independent counterparts
('emit -> Q_EMIT', etc)

* Indentation fixes (80 character column-width)

* Rearragned #include statements: from most platform-independen to more
app-specific.

* Fixed some grammar typos.

* README.md updated respectively.