### PR TITLE
Allow any instance of application became secondary

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,14 @@ SingleApplication app( argc, argv, 2 );
 After which just call your program with the `--secondary` argument to launch a
 secondary instance.
 
+Also you can allow any instance of program became secondary with setting
+static property of SingleApplication class.
+
+```cpp
+SingleApplication::setAllowSecondary(true);
+SingleApplication app( argc, argv, 2 );
+```
+
 You can check whether your instance is a primary or secondary with the following
 methods:
 

--- a/singleapplication.cpp
+++ b/singleapplication.cpp
@@ -13,6 +13,9 @@
 
 #include "singleapplication.h"
 
+
+bool SingleApplication::_allowSecondary = false;
+
 struct InstancesInfo {
     bool primary;
     uint8_t secondary;
@@ -170,7 +173,7 @@ SingleApplication::SingleApplication( int &argc, char *argv[], uint8_t secondary
 #ifdef Q_OS_UNIX
     bool forcePrimary = false;
 #endif
-    bool secondary = false;
+    bool secondary = allowSecondary();
     for( int i = 0; i < argc; ++i ) {
         if( strcmp( argv[i], "--secondary" ) == 0 ) {
             secondary = true;
@@ -191,7 +194,7 @@ SingleApplication::SingleApplication( int &argc, char *argv[], uint8_t secondary
     serverName.replace( QRegExp("[^\\w\\-. ]"), "" );
 
     // Guarantee thread safe behaviour with a shared memory block. Also by
-    // attaching to it and deleting it we make sure that the memory i deleted
+    // attaching to it and deleting it we make sure that the memory is deleted
     // even if the process had crashed
     d->memory = new QSharedMemory( serverName );
     d->memory->attach();
@@ -254,6 +257,16 @@ bool SingleApplication::isSecondary()
 {
     Q_D(SingleApplication);
     return d->server == NULL;
+}
+
+bool SingleApplication::allowSecondary()
+{
+    return _allowSecondary;
+}
+
+void SingleApplication::setAllowSecondary(bool allow)
+{
+    _allowSecondary = allow;
 }
 
 /**

--- a/singleapplication.h
+++ b/singleapplication.h
@@ -29,6 +29,9 @@ public:
     bool isPrimary();
     bool isSecondary();
 
+    static bool allowSecondary();
+    static void setAllowSecondary(bool allow);
+
 Q_SIGNALS:
     void showUp();
 
@@ -37,6 +40,7 @@ private Q_SLOTS:
 
 private:
     SingleApplicationPrivate *d_ptr;
+    static bool _allowSecondary;
 };
 
 #endif // SINGLE_APPLICATION_H

--- a/singleapplication.h
+++ b/singleapplication.h
@@ -10,6 +10,7 @@
 #include QT_STRINGIFY(QAPPLICATION_CLASS)
 
 class SingleApplicationPrivate;
+class QJsonObject;
 
 /**
  * @brief The SingleApplication class handles multipe instances of the same Application
@@ -32,11 +33,15 @@ public:
     static bool allowSecondary();
     static void setAllowSecondary(bool allow);
 
+    void sendCommand(const QJsonObject& obj);
+
 Q_SIGNALS:
     void showUp();
+    void command(const QJsonObject& obj);
 
 private Q_SLOTS:
     void slotConnectionEstablished();
+    void dataReady();
 
 private:
     SingleApplicationPrivate *d_ptr;


### PR DESCRIPTION
Add allowSecondary static property to SingleApplication class. 
Sometimes using '--secondary' command line key is not possible. Added static property allows any instance of program starts as secondary.