### PR TITLE
Allow to exclude some data from hashing the server name & some Windows-related improvements

### DIFF
--- a/singleapplication.cpp
+++ b/singleapplication.cpp
@@ -118,11 +118,15 @@ void SingleApplicationPrivate::startPrimary( bool resetMemory )
     // So we start a QLocalServer to listen for connections
     QLocalServer::removeServer( blockServerName );
     server = new QLocalServer();
-#ifdef Q_OS_WIN
-    // To allow a non elevated process to connect to a local server
-    // created by an elevated process run by the same user
-    server->setSocketOptions( QLocalServer::UserAccessOption );
-#endif
+
+    // Restrict access to the socket according to the
+    // SingleApplication::Mode::User flag on User level or no restrictions
+    if( options & SingleApplication::Mode::User ) {
+      server->setSocketOptions( QLocalServer::UserAccessOption );
+    } else {
+      server->setSocketOptions( QLocalServer::WorldAccessOption );
+    }
+
     server->listen( blockServerName );
     QObject::connect(
         server,

--- a/singleapplication.cpp
+++ b/singleapplication.cpp
@@ -58,11 +58,18 @@ void SingleApplicationPrivate::genBlockServerName( int timeout )
 {
     QCryptographicHash appData( QCryptographicHash::Sha256 );
     appData.addData( "SingleApplication", 17 );
-    appData.addData( SingleApplication::app_t::applicationName().toUtf8() );
-    appData.addData( SingleApplication::app_t::applicationVersion().toUtf8() );
-    appData.addData( SingleApplication::app_t::applicationFilePath().toUtf8() );
-    appData.addData( SingleApplication::app_t::organizationName().toUtf8() );
-    appData.addData( SingleApplication::app_t::organizationDomain().toUtf8() );
+    appData.addData(SingleApplication::app_t::applicationName().toUtf8());
+    appData.addData(SingleApplication::app_t::organizationName().toUtf8());
+    appData.addData(SingleApplication::app_t::organizationDomain().toUtf8());
+
+    if (!(options & SingleApplication::Mode::ExcludeAppVersion))
+        appData.addData(SingleApplication::app_t::applicationVersion().toUtf8());
+    if (!(options & SingleApplication::Mode::ExcludeAppPath))
+#ifdef Q_OS_WIN
+        appData.addData(SingleApplication::app_t::applicationFilePath().toLower().toUtf8());
+#else
+        appData.addData(SingleApplication::app_t::applicationFilePath().toUtf8());
+#endif
 
     // User level block requires a user specific data in the hash
     if( options & SingleApplication::Mode::User ) {

--- a/singleapplication.cpp
+++ b/singleapplication.cpp
@@ -58,17 +58,17 @@ void SingleApplicationPrivate::genBlockServerName( int timeout )
 {
     QCryptographicHash appData( QCryptographicHash::Sha256 );
     appData.addData( "SingleApplication", 17 );
-    appData.addData(SingleApplication::app_t::applicationName().toUtf8());
-    appData.addData(SingleApplication::app_t::organizationName().toUtf8());
-    appData.addData(SingleApplication::app_t::organizationDomain().toUtf8());
+    appData.addData( SingleApplication::app_t::applicationName().toUtf8() );
+    appData.addData( SingleApplication::app_t::organizationName().toUtf8() );
+    appData.addData( SingleApplication::app_t::organizationDomain().toUtf8() );
 
-    if (!(options & SingleApplication::Mode::ExcludeAppVersion))
-        appData.addData(SingleApplication::app_t::applicationVersion().toUtf8());
-    if (!(options & SingleApplication::Mode::ExcludeAppPath))
+    if ( ! (options & SingleApplication::Mode::ExcludeAppVersion) )
+        appData.addData( SingleApplication::app_t::applicationVersion().toUtf8() );
+    if ( ! (options & SingleApplication::Mode::ExcludeAppPath) )
 #ifdef Q_OS_WIN
-        appData.addData(SingleApplication::app_t::applicationFilePath().toLower().toUtf8());
+        appData.addData( SingleApplication::app_t::applicationFilePath().toLower().toUtf8() );
 #else
-        appData.addData(SingleApplication::app_t::applicationFilePath().toUtf8());
+        appData.addData( SingleApplication::app_t::applicationFilePath().toUtf8() );
 #endif
 
     // User level block requires a user specific data in the hash
@@ -118,7 +118,7 @@ void SingleApplicationPrivate::startPrimary( bool resetMemory )
 #ifdef Q_OS_WIN
     // To allow a non elevated process to connect to a local server
     // created by an elevated process run by the same user
-    server->setSocketOptions(QLocalServer::UserAccessOption);
+    server->setSocketOptions( QLocalServer::UserAccessOption );
 #endif
     server->listen( blockServerName );
     QObject::connect(

--- a/singleapplication.cpp
+++ b/singleapplication.cpp
@@ -115,6 +115,11 @@ void SingleApplicationPrivate::startPrimary( bool resetMemory )
     // So we start a QLocalServer to listen for connections
     QLocalServer::removeServer( blockServerName );
     server = new QLocalServer();
+#ifdef Q_OS_WIN
+    // To allow a non elevated process to connect to a local server
+    // created by an elevated process run by the same user
+    server->setSocketOptions(QLocalServer::UserAccessOption);
+#endif
     server->listen( blockServerName );
     QObject::connect(
         server,

--- a/singleapplication.cpp
+++ b/singleapplication.cpp
@@ -62,14 +62,17 @@ void SingleApplicationPrivate::genBlockServerName( int timeout )
     appData.addData( SingleApplication::app_t::organizationName().toUtf8() );
     appData.addData( SingleApplication::app_t::organizationDomain().toUtf8() );
 
-    if ( ! (options & SingleApplication::Mode::ExcludeAppVersion) )
+    if( ! (options & SingleApplication::Mode::ExcludeAppVersion) ) {
         appData.addData( SingleApplication::app_t::applicationVersion().toUtf8() );
-    if ( ! (options & SingleApplication::Mode::ExcludeAppPath) )
+    }
+
+    if( ! (options & SingleApplication::Mode::ExcludeAppPath) ) {
 #ifdef Q_OS_WIN
         appData.addData( SingleApplication::app_t::applicationFilePath().toLower().toUtf8() );
 #else
         appData.addData( SingleApplication::app_t::applicationFilePath().toUtf8() );
 #endif
+    }
 
     // User level block requires a user specific data in the hash
     if( options & SingleApplication::Mode::User ) {

--- a/singleapplication.h
+++ b/singleapplication.h
@@ -59,7 +59,9 @@ public:
     enum Mode {
         User                    = 1 << 0,
         System                  = 1 << 1,
-        SecondaryNotification   = 1 << 2
+        SecondaryNotification   = 1 << 2,
+        ExcludeAppVersion       = 1 << 3,
+		ExcludeAppPath          = 1 << 4
     };
     Q_DECLARE_FLAGS(Options, Mode)
 

--- a/singleapplication.h
+++ b/singleapplication.h
@@ -61,7 +61,7 @@ public:
         System                  = 1 << 1,
         SecondaryNotification   = 1 << 2,
         ExcludeAppVersion       = 1 << 3,
-		ExcludeAppPath          = 1 << 4
+        ExcludeAppPath          = 1 << 4
     };
     Q_DECLARE_FLAGS(Options, Mode)
 


### PR DESCRIPTION
Some applications may need to force single instance regardless of the application version or the application file path.

On Windows, the file path is case-insensitive, so the application file path need to be lowercased first before used for hashing.

According to Qt's document, QLocalServer::UserAccessOption needs to be set on the socket server, so that a non elevated process can connect to the server created by an elevated process.