### PR TITLE
Fix crash when username contains Unicode characters

### DIFF
--- a/singleapplication.cpp
+++ b/singleapplication.cpp
@@ -118,11 +118,15 @@ void SingleApplicationPrivate::startPrimary( bool resetMemory )
     // So we start a QLocalServer to listen for connections
     QLocalServer::removeServer( blockServerName );
     server = new QLocalServer();
-#ifdef Q_OS_WIN
-    // To allow a non elevated process to connect to a local server
-    // created by an elevated process run by the same user
-    server->setSocketOptions( QLocalServer::UserAccessOption );
-#endif
+
+    // Restrict access to the socket according to the
+    // SingleApplication::Mode::User flag on User level or no restrictions
+    if( options & SingleApplication::Mode::User ) {
+      server->setSocketOptions( QLocalServer::UserAccessOption );
+    } else {
+      server->setSocketOptions( QLocalServer::WorldAccessOption );
+    }
+
     server->listen( blockServerName );
     QObject::connect(
         server,

--- a/singleapplication.cpp
+++ b/singleapplication.cpp
@@ -82,7 +82,7 @@ void SingleApplicationPrivate::genBlockServerName( int timeout )
         // Specifies size of the buffer on input
         DWORD usernameLength = UNLEN + 1;
         if( GetUserName( username, &usernameLength ) ) {
-            appData.addData( QString::fromWCharArray(str).toUtf8() );
+            appData.addData( QString::fromWCharArray(username).toUtf8() );
         } else {
             appData.addData( QStandardPaths::standardLocations( QStandardPaths::HomeLocation ).join("").toUtf8() );
         }

--- a/singleapplication.cpp
+++ b/singleapplication.cpp
@@ -58,11 +58,18 @@ void SingleApplicationPrivate::genBlockServerName( int timeout )
 {
     QCryptographicHash appData( QCryptographicHash::Sha256 );
     appData.addData( "SingleApplication", 17 );
-    appData.addData( SingleApplication::app_t::applicationName().toUtf8() );
-    appData.addData( SingleApplication::app_t::applicationVersion().toUtf8() );
-    appData.addData( SingleApplication::app_t::applicationFilePath().toUtf8() );
-    appData.addData( SingleApplication::app_t::organizationName().toUtf8() );
-    appData.addData( SingleApplication::app_t::organizationDomain().toUtf8() );
+    appData.addData(SingleApplication::app_t::applicationName().toUtf8());
+    appData.addData(SingleApplication::app_t::organizationName().toUtf8());
+    appData.addData(SingleApplication::app_t::organizationDomain().toUtf8());
+
+    if (!(options & SingleApplication::Mode::ExcludeAppVersion))
+        appData.addData(SingleApplication::app_t::applicationVersion().toUtf8());
+    if (!(options & SingleApplication::Mode::ExcludeAppPath))
+#ifdef Q_OS_WIN
+        appData.addData(SingleApplication::app_t::applicationFilePath().toLower().toUtf8());
+#else
+        appData.addData(SingleApplication::app_t::applicationFilePath().toUtf8());
+#endif
 
     // User level block requires a user specific data in the hash
     if( options & SingleApplication::Mode::User ) {

--- a/singleapplication.cpp
+++ b/singleapplication.cpp
@@ -58,17 +58,17 @@ void SingleApplicationPrivate::genBlockServerName( int timeout )
 {
     QCryptographicHash appData( QCryptographicHash::Sha256 );
     appData.addData( "SingleApplication", 17 );
-    appData.addData(SingleApplication::app_t::applicationName().toUtf8());
-    appData.addData(SingleApplication::app_t::organizationName().toUtf8());
-    appData.addData(SingleApplication::app_t::organizationDomain().toUtf8());
+    appData.addData( SingleApplication::app_t::applicationName().toUtf8() );
+    appData.addData( SingleApplication::app_t::organizationName().toUtf8() );
+    appData.addData( SingleApplication::app_t::organizationDomain().toUtf8() );
 
-    if (!(options & SingleApplication::Mode::ExcludeAppVersion))
-        appData.addData(SingleApplication::app_t::applicationVersion().toUtf8());
-    if (!(options & SingleApplication::Mode::ExcludeAppPath))
+    if ( ! (options & SingleApplication::Mode::ExcludeAppVersion) )
+        appData.addData( SingleApplication::app_t::applicationVersion().toUtf8() );
+    if ( ! (options & SingleApplication::Mode::ExcludeAppPath) )
 #ifdef Q_OS_WIN
-        appData.addData(SingleApplication::app_t::applicationFilePath().toLower().toUtf8());
+        appData.addData( SingleApplication::app_t::applicationFilePath().toLower().toUtf8() );
 #else
-        appData.addData(SingleApplication::app_t::applicationFilePath().toUtf8());
+        appData.addData( SingleApplication::app_t::applicationFilePath().toUtf8() );
 #endif
 
     // User level block requires a user specific data in the hash
@@ -118,7 +118,7 @@ void SingleApplicationPrivate::startPrimary( bool resetMemory )
 #ifdef Q_OS_WIN
     // To allow a non elevated process to connect to a local server
     // created by an elevated process run by the same user
-    server->setSocketOptions(QLocalServer::UserAccessOption);
+    server->setSocketOptions( QLocalServer::UserAccessOption );
 #endif
     server->listen( blockServerName );
     QObject::connect(

--- a/singleapplication.cpp
+++ b/singleapplication.cpp
@@ -115,6 +115,11 @@ void SingleApplicationPrivate::startPrimary( bool resetMemory )
     // So we start a QLocalServer to listen for connections
     QLocalServer::removeServer( blockServerName );
     server = new QLocalServer();
+#ifdef Q_OS_WIN
+    // To allow a non elevated process to connect to a local server
+    // created by an elevated process run by the same user
+    server->setSocketOptions(QLocalServer::UserAccessOption);
+#endif
     server->listen( blockServerName );
     QObject::connect(
         server,

--- a/singleapplication.cpp
+++ b/singleapplication.cpp
@@ -62,14 +62,17 @@ void SingleApplicationPrivate::genBlockServerName( int timeout )
     appData.addData( SingleApplication::app_t::organizationName().toUtf8() );
     appData.addData( SingleApplication::app_t::organizationDomain().toUtf8() );
 
-    if ( ! (options & SingleApplication::Mode::ExcludeAppVersion) )
+    if( ! (options & SingleApplication::Mode::ExcludeAppVersion) ) {
         appData.addData( SingleApplication::app_t::applicationVersion().toUtf8() );
-    if ( ! (options & SingleApplication::Mode::ExcludeAppPath) )
+    }
+
+    if( ! (options & SingleApplication::Mode::ExcludeAppPath) ) {
 #ifdef Q_OS_WIN
         appData.addData( SingleApplication::app_t::applicationFilePath().toLower().toUtf8() );
 #else
         appData.addData( SingleApplication::app_t::applicationFilePath().toUtf8() );
 #endif
+    }
 
     // User level block requires a user specific data in the hash
     if( options & SingleApplication::Mode::User ) {

--- a/singleapplication.cpp
+++ b/singleapplication.cpp
@@ -82,9 +82,7 @@ void SingleApplicationPrivate::genBlockServerName( int timeout )
         // Specifies size of the buffer on input
         DWORD usernameLength = UNLEN + 1;
         if( GetUserName( username, &usernameLength ) ) {
-            char buffer[512];
-            size_t length = wcstombs( buffer, username, 512 );
-            appData.addData( buffer, length );
+            appData.addData( QString::fromWCharArray(str).toUtf8() );
         } else {
             appData.addData( QStandardPaths::standardLocations( QStandardPaths::HomeLocation ).join("").toUtf8() );
         }

--- a/singleapplication.h
+++ b/singleapplication.h
@@ -59,7 +59,9 @@ public:
     enum Mode {
         User                    = 1 << 0,
         System                  = 1 << 1,
-        SecondaryNotification   = 1 << 2
+        SecondaryNotification   = 1 << 2,
+        ExcludeAppVersion       = 1 << 3,
+		ExcludeAppPath          = 1 << 4
     };
     Q_DECLARE_FLAGS(Options, Mode)
 

--- a/singleapplication.h
+++ b/singleapplication.h
@@ -61,7 +61,7 @@ public:
         System                  = 1 << 1,
         SecondaryNotification   = 1 << 2,
         ExcludeAppVersion       = 1 << 3,
-		ExcludeAppPath          = 1 << 4
+        ExcludeAppPath          = 1 << 4
     };
     Q_DECLARE_FLAGS(Options, Mode)
 


### PR DESCRIPTION
When username contains Unicode characters, [wcstombs()](http://www.cplusplus.com/reference/cstdlib/wcstombs/) may fail to translate it and return (size_t)-1.

`length = (size_t)-1` is a very large unsigned number and will cause `appData.addData( username, length )` to crash.

Example:
```
const wchar_t str[] = L"测试";
char buffer[512];
size_t length = wcstombs( buffer, str, 512 );
// now length is 18446744073709551615
```

