### PR TITLE
Fix memory leak on SingleApplicationPrivate destruction

### DIFF
--- a/singleapplication.cpp
+++ b/singleapplication.cpp
@@ -239,6 +239,7 @@ void SingleApplicationPrivate::cleanUp() {
     InstancesInfo* inst = (InstancesInfo*)memory->data();
     if( server != nullptr ) {
         server->close();
+        delete server;
         inst->primary = false;
     }
     memory->unlock();


### PR DESCRIPTION
When SingleApplicationPrivate instance destroys, QLocalServer object instance (_server_) will not be destroyed and the memory allocated for it will leak.