### PR TITLE
Fixed compilation error: cannot convert wchar_t* to LPSTR {aka char*}

### DIFF
--- a/singleapplication.cpp
+++ b/singleapplication.cpp
@@ -99,7 +99,7 @@ void SingleApplicationPrivate::genBlockServerName( int timeout )
         wchar_t username [ UNLEN + 1 ];
         // Specifies size of the buffer on input
         DWORD usernameLength = UNLEN + 1;
-        if( GetUserName( username, &usernameLength ) ) {
+        if( GetUserNameW( username, &usernameLength ) ) {
             appData.addData( QString::fromWCharArray(username).toUtf8() );
         } else {
             appData.addData( QStandardPaths::standardLocations( QStandardPaths::HomeLocation ).join("").toUtf8() );


### PR DESCRIPTION
When I'm trying to build singleapplication using cross-compilation (MXE (M cross environment)) a compilation error appears :
singleapplication.cpp: In member function 'void SingleApplicationPrivate::genBlockServerName(int)':
singleapplication.cpp:102:52: error: cannot convert 'wchar_t*' to 'LPSTR {aka char*}' for argument '1' to 'WINBOOL GetUserNameA(LPSTR, LPDWORD)'
         if( GetUserName( username, &usernameLength ) ) { 

Mingw32 in MXE for some reason can not by itself determine the appropriate type for the function.
Using GetUserNameW instead GetUserName fixes the problem