### PR TITLE
System wide shared memory in Windows.

### DIFF
--- a/singleapplication.cpp
+++ b/singleapplication.cpp
@@ -99,7 +99,7 @@ void SingleApplicationPrivate::genBlockServerName( int timeout )
         wchar_t username [ UNLEN + 1 ];
         // Specifies size of the buffer on input
         DWORD usernameLength = UNLEN + 1;
-        if( GetUserName( username, &usernameLength ) ) {
+        if( GetUserNameW( username, &usernameLength ) ) {
             appData.addData( QString::fromWCharArray(username).toUtf8() );
         } else {
             appData.addData( QStandardPaths::standardLocations( QStandardPaths::HomeLocation ).join("").toUtf8() );

--- a/singleapplication.cpp
+++ b/singleapplication.cpp
@@ -264,27 +264,28 @@ void SingleApplicationPrivate::connectToPrimary( int msecs, char connectionType 
     bool SingleApplicationPrivate::isRunAsAdmin()
     {
         BOOL isRunAsAdmin = FALSE;
-        BOOL sidAllocationSucceed = FALSE;
+        BOOL sidAllocationSuccess = FALSE;
         PSID pAdministratorsGroup = NULL;
 
         // Allocate and initialize a SID of the administrators group.
         SID_IDENTIFIER_AUTHORITY NtAuthority = SECURITY_NT_AUTHORITY;
-        sidAllocationSucceed = AllocateAndInitializeSid(
+        sidAllocationSuccess = AllocateAndInitializeSid(
             &NtAuthority,
             2,
             SECURITY_BUILTIN_DOMAIN_RID,
             DOMAIN_ALIAS_RID_ADMINS,
             0, 0, 0, 0, 0, 0,
-            &pAdministratorsGroup);
+            &pAdministratorsGroup
+        );
 
-        if( sidAllocationSucceed ) {
+        if( sidAllocationSuccess ) {
             // Determine whether the SID of administrators group is enabled in
             // the primary access token of the process.
-            if( !CheckTokenMembership(NULL, pAdministratorsGroup, &isRunAsAdmin) ) {
+            if( !CheckTokenMembership( NULL, pAdministratorsGroup, &isRunAsAdmin ) ) {
                 isRunAsAdmin = FALSE;
             }
 
-            FreeSid(pAdministratorsGroup);
+            FreeSid( pAdministratorsGroup );
         }
 
         return isRunAsAdmin;
@@ -417,7 +418,7 @@ SingleApplication::SingleApplication( int &argc, char *argv[], bool allowSeconda
 #ifdef Q_OS_WIN
     if( (options & Mode::System) && d->isRunAsAdmin() ){
         QSharedMemory *memory = new QSharedMemory();
-        memory->setNativeKey("Global\\" + d->blockServerName);
+        memory->setNativeKey( "Global\\" + d->blockServerName );
         d->memory = memory;
     }
     else

--- a/singleapplication_p.h
+++ b/singleapplication_p.h
@@ -63,6 +63,10 @@ public:
     static QMutex sharedMemMutex;
 #endif
 
+#ifdef Q_OS_WIN
+    bool isRunAsAdmin();
+#endif
+
     QSharedMemory *memory;
     SingleApplication *q_ptr;
     QLocalSocket *socket;


### PR DESCRIPTION
To make a unique system wide shared memory in Windows its name should be prefixed with "Global\" but creating an object in global namespace require administrator privilege.
First I check if the single application mode is System, then I check for admin rights, if it is satisfied I create a shared memory in global namespace otherwise the memory will be created in local namespace then the application will be single only user wide.
Checking admin right code is base on [this MSDN page](https://msdn.microsoft.com/en-us/library/aa376389(v=VS.85).aspx).
[More info](https://msdn.microsoft.com/en-us/library/windows/desktop/aa366537(v=vs.85).aspx) about shared memory in global space.
