### PR TITLE
Added the ability to bring the primary application window to the foreground

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,42 @@ Using `SingleApplication::instance()` is a neat way to get the
 `SingleApplication` instance for binding to it's signals anywhere in your
 program.
 
+__Note:__ On Windows systems the ability to set the application to the front of
+the desktop is restricted, see
+[AllowSetForegroundWindow](https://msdn.microsoft.com/en-us/library/windows/desktop/ms632668.aspx)
+for more details.
+Two rules say that the process that can allow setting the foreground window is
+the foreground process or was started by the foreground process. So to correctly
+use this, the secondary application instance must call this SDK function with
+the process ID of the primary application instance. This allows the primary
+application to set its window to the foreground.
+
+*To make this work the `SingleApplication` must be constructed with `allowSecondary`
+parameter set to `true` and the `options` parameter must contain
+`Mode::SecondaryNotification`, See `SingleApplication::Mode` for more details.*
+
+```cpp
+If ( app.isSecondary() ) {
+    // This API requires LIBS += User32.lib to be added to the project
+    AllowSetForegroundWindow( DWORD( app.getPrimaryPid() ) );
+}
+
+If ( app.isPrimary() ) {
+    QObject::connect(
+        &app,
+        &SingleApplication::instanceStarted,
+        this,
+        &MyApp::instanceAppStarted
+    );
+}
+```
+
+```cpp
+void MyApp::instanceAppStarted() {
+    setActiveWindow( [window/widget to set to the foreground] );
+}
+```
+
 Secondary Instances
 -------------------
 

--- a/singleapplication.h
+++ b/singleapplication.h
@@ -54,21 +54,14 @@ public:
      * @note Operating system can restrict the shared memory blocks to the same
      * user, in which case the User/System modes will have no effect and the
      * block will be user wide.
-     * @note BringPrimaryToForeground currently only work on Windows systems and
-     * only when the QAPPLICATION_CLASS is defined as QApplication. To set the
-     * window to the foreground, the application must be a windows application with
-     * a clearly defined main windows, i.e. derived from QMainWindow. Because
-     * the primary window needs to eb informed that it must go to the foreground,
-     * the SecondaryNotification flag must also be set to use this
      * @enum
      */
     enum Mode {
-        User                        = 1 << 0,
-        System                      = 1 << 1,
-        SecondaryNotification       = 1 << 2,
-        ExcludeAppVersion           = 1 << 3,
-        ExcludeAppPath              = 1 << 4,
-        BringPrimaryToForeground    = 1 << 5
+        User                    = 1 << 0,
+        System                  = 1 << 1,
+        SecondaryNotification   = 1 << 2,
+        ExcludeAppVersion       = 1 << 3,
+        ExcludeAppPath          = 1 << 4
     };
     Q_DECLARE_FLAGS(Options, Mode)
 
@@ -112,6 +105,12 @@ public:
      * @returns {int}
      */
     quint32 instanceId();
+
+    /**
+     * @brief Returns the process ID (PID) of the primary instance
+     * @returns {int}
+     */
+    qint64 getPrimaryPid();
 
     /**
      * @brief Sends a message to the primary instance. Returns true on success.

--- a/singleapplication.h
+++ b/singleapplication.h
@@ -54,14 +54,21 @@ public:
      * @note Operating system can restrict the shared memory blocks to the same
      * user, in which case the User/System modes will have no effect and the
      * block will be user wide.
+     * @note BringPrimaryToForeground currently only work on Windows systems and
+     * only when the QAPPLICATION_CLASS is defined as QApplication. To set the
+     * window to the foreground, the application must be a windows application with
+     * a clearly defined main windows, i.e. derived from QMainWindow. Because
+     * the primary window needs to eb informed that it must go to the foreground,
+     * the SecondaryNotification flag must also be set to use this
      * @enum
      */
     enum Mode {
-        User                    = 1 << 0,
-        System                  = 1 << 1,
-        SecondaryNotification   = 1 << 2,
-        ExcludeAppVersion       = 1 << 3,
-        ExcludeAppPath          = 1 << 4
+        User                        = 1 << 0,
+        System                      = 1 << 1,
+        SecondaryNotification       = 1 << 2,
+        ExcludeAppVersion           = 1 << 3,
+        ExcludeAppPath              = 1 << 4,
+        BringPrimaryToForeground    = 1 << 5
     };
     Q_DECLARE_FLAGS(Options, Mode)
 

--- a/singleapplication.pri
+++ b/singleapplication.pri
@@ -8,6 +8,6 @@ SOURCES += $$PWD/singleapplication.cpp
 INCLUDEPATH += $$PWD
 
 win32 {
-    msvc:LIBS += Advapi32.lib
+    msvc:LIBS += Advapi32.lib User32.lib
     gcc:LIBS += -lAdvapi32
 }

--- a/singleapplication.pri
+++ b/singleapplication.pri
@@ -8,6 +8,6 @@ SOURCES += $$PWD/singleapplication.cpp
 INCLUDEPATH += $$PWD
 
 win32 {
-    msvc:LIBS += Advapi32.lib User32.lib
+    msvc:LIBS += Advapi32.lib
     gcc:LIBS += -lAdvapi32
 }

--- a/singleapplication_p.h
+++ b/singleapplication_p.h
@@ -40,6 +40,9 @@
 struct InstancesInfo {
     bool primary;
     quint32 secondary;
+#ifdef Q_OS_WIN
+    qint64 primaryPid;  // The process PID is used to enable moving the main window tot eh foreground on Windows systems
+#endif
 };
 
 class SingleApplicationPrivate : public QObject {

--- a/singleapplication_p.h
+++ b/singleapplication_p.h
@@ -40,9 +40,7 @@
 struct InstancesInfo {
     bool primary;
     quint32 secondary;
-#ifdef Q_OS_WIN
-    qint64 primaryPid;  // The process PID is used to enable moving the main window tot eh foreground on Windows systems
-#endif
+    qint64 primaryPid;
 };
 
 class SingleApplicationPrivate : public QObject {
@@ -57,6 +55,7 @@ public:
     void startPrimary( bool resetMemory );
     void startSecondary();
     void connectToPrimary( int msecs, char connectionType );
+    qint64 getPrimaryPid();
 
 #ifdef Q_OS_UNIX
     void crashHandler();


### PR DESCRIPTION
The SingleApplication framework is really great and just what I needed. Especially the feature to let the secondary application inform the primary application about it existence and startup instructions. This enable the primary application to followup the secondary application instructions.

The only this I missed was the ability to enforce the primary application to the foreground to inform the user of the action.

The development where I need this functionality is on the Windows platform. On that system the OS supports bringing a window to the front only when it meets certain criteria. One of them is that the process that allows this must be the foreground process. In this case it would be the secondary application.
This made to step to develop it in the framework logical.

So now the secondary application, when instructed by the newly added option BringPrimaryToForeground, will allow the primary application to bring its window to the foreground. For this the two instances must communicate so I enabled this feature only when the option SecondaryNotification is also set.

Unfortunately I only implemented it for Windows systems and because the supporting functionality on the Qt side was mainly present in the QApplication, I added this condition as well with an extra condition to have a QMainWindow to be sure that the whole application gets to the front.
Due to the use of a Windows API an extra dependency on the User32.dll had to be added.

There is one annoying warning left in the SingleApplicationPrivate::startPrimary function where the Q_Q macro is being used. Couldn't find how to resolve this one.

I hope this new feature will help