### PR TITLE
replace -lAdvapi32 with -ladvapi32 which broke the build on mxe

### DIFF
--- a/singleapplication.pri
+++ b/singleapplication.pri
@@ -9,7 +9,7 @@ INCLUDEPATH += $$PWD
 
 win32 {
     msvc:LIBS += Advapi32.lib
-    gcc:LIBS += -lAdvapi32
+    gcc:LIBS += -ladvapi32
 }
 
 DISTFILES += \


### PR DESCRIPTION
This should not break any windows builds as the windows filesystem is case-insensitive.