### PR TITLE
Fix sendmessage

### DIFF
--- a/examples/basic/main.cpp
+++ b/examples/basic/main.cpp
@@ -1,4 +1,4 @@
-#include <SingleApplication.h>
+#include <singleapplication.h>
 
 int main(int argc, char *argv[])
 {

--- a/examples/calculator/main.cpp
+++ b/examples/calculator/main.cpp
@@ -50,7 +50,7 @@
 
 #include <QApplication>
 
-#include <SingleApplication.h>
+#include <singleapplication.h>
 
 #include "calculator.h"
 

--- a/examples/sending_arguments/main.cpp
+++ b/examples/sending_arguments/main.cpp
@@ -1,4 +1,4 @@
-#include <SingleApplication.h>
+#include <singleapplication.h>
 #include "messagereceiver.h"
 
 int main(int argc, char *argv[])


### PR DESCRIPTION
I was having a bug to send a message to the primary app. The message sent by the second process was not received correctly. The issue is here: 

```c++
        QByteArray msgBytes = nextConnSocket->read(nextConnSocket->bytesAvailable() - static_cast<qint64>(sizeof(quint16)));
        QByteArray checksumBytes = nextConnSocket->read(sizeof(quint16));
```

When the message is sent immediately following a connection, both messages are concatenated and available to read. Therefore, the checksum is read beyond the init message and that causes an invalid connection.

The other patch is simply a case fix of the include file. On Linux, the file system is case sensitive and without the correct case, the include file is not found.

Thanks!