### PR TITLE
Async socket processing

### DIFF
--- a/singleapplication_p.cpp
+++ b/singleapplication_p.cpp
@@ -101,7 +101,6 @@ void SingleApplicationPrivate::genBlockServerName()
     // User level block requires a user specific data in the hash
     if( options & SingleApplication::Mode::User ) {
 #ifdef Q_OS_WIN
-        Q_UNUSED(timeout);
         wchar_t username [ UNLEN + 1 ];
         // Specifies size of the buffer on input
         DWORD usernameLength = UNLEN + 1;

--- a/singleapplication_p.cpp
+++ b/singleapplication_p.cpp
@@ -280,7 +280,7 @@ void SingleApplicationPrivate::slotConnectionEstablished()
                 readInitMessageBody(nextConnSocket);
                 break;
             case StageConnected:
-                Q_EMIT this->slotDataAvailable( socket, info.instanceId );
+                Q_EMIT this->slotDataAvailable( nextConnSocket, info.instanceId );
                 break;
             default:
                 break;

--- a/singleapplication_p.cpp
+++ b/singleapplication_p.cpp
@@ -353,8 +353,8 @@ void SingleApplicationPrivate::readInitMessageBody( QLocalSocket *sock )
     const quint16 actualChecksum = qChecksum( msgBytes.constData(), static_cast<quint32>( msgBytes.length() - sizeof( quint16 ) ) );
 
     bool isValid = readStream.status() == QDataStream::Ok &&
-                   QLatin1String(latin1Name) != blockServerName &&
-                   msgChecksum != actualChecksum;
+                   QLatin1String(latin1Name) == blockServerName &&
+                   msgChecksum == actualChecksum;
 
     if( !isValid ) {
         sock->close();

--- a/singleapplication_p.h
+++ b/singleapplication_p.h
@@ -44,6 +44,14 @@ struct InstancesInfo {
     quint16 checksum;
 };
 
+struct ConnectionInfo {
+    explicit ConnectionInfo() :
+        msgLen(0), instanceId(0), stage(0) {}
+    qint64 msgLen;
+    quint32 instanceId;
+    quint8 stage;
+};
+
 class SingleApplicationPrivate : public QObject {
 Q_OBJECT
 public:
@@ -52,6 +60,11 @@ public:
         NewInstance = 1,
         SecondaryInstance = 2,
         Reconnect = 3
+    };
+    enum ConnectionStage : quint8 {
+        StageHeader = 0,
+        StageBody = 1,
+        StageConnected = 2,
     };
     Q_DECLARE_PUBLIC(SingleApplication)
 
@@ -65,6 +78,8 @@ public:
     void connectToPrimary(int msecs, ConnectionType connectionType );
     quint16 blockChecksum();
     qint64 primaryPid();
+    void readInitMessageHeader(QLocalSocket *socket);
+    void readInitMessageBody(QLocalSocket *socket);
 
     SingleApplication *q_ptr;
     QSharedMemory *memory;
@@ -73,6 +88,7 @@ public:
     quint32 instanceNumber;
     QString blockServerName;
     SingleApplication::Options options;
+    QMap<QLocalSocket*, ConnectionInfo> connectionMap;
 
 public Q_SLOTS:
     void slotConnectionEstablished();


### PR DESCRIPTION
The waitForReadyRead() is blocking the event loop of the main application. This patch introduces asynchronous event processing of the initialization message. Because we receive the header and the body in possibly two steps, the state is keept in a map.

This solves a crash during the checksum computation due to an empty buffer. This condition was occuring because the message header and the body may not be available at once. We should read only when the bytes are actually availables.

There is also a small fix on Windows, where the compilation was failing due to an undefined variable.

Thanks!