### PR TITLE
instanceAbortedFunction implementation

### DIFF
--- a/singleapplication.cpp
+++ b/singleapplication.cpp
@@ -36,7 +36,7 @@
  * @param argv
  * @param {bool} allowSecondaryInstances
  */
-SingleApplication::SingleApplication( int &argc, char *argv[], bool allowSecondary, Options options, int timeout )
+SingleApplication::SingleApplication( int &argc, char *argv[], bool allowSecondary, Options options, int timeout, std::function<void()> instanceAbortedFunction )
     : app_t( argc, argv ), d_ptr( new SingleApplicationPrivate( this ) )
 {
     Q_D(SingleApplication);
@@ -120,6 +120,11 @@ SingleApplication::SingleApplication( int &argc, char *argv[], bool allowSeconda
     d->connectToPrimary( timeout, SingleApplicationPrivate::NewInstance );
 
     delete d;
+
+    // Call user function if application will be aborted
+    if( instanceAbortedFunction != Q_NULLPTR ) {
+        instanceAbortedFunction();
+    }
 
     ::exit( EXIT_SUCCESS );
 }

--- a/singleapplication.h
+++ b/singleapplication.h
@@ -23,6 +23,7 @@
 #ifndef SINGLE_APPLICATION_H
 #define SINGLE_APPLICATION_H
 
+#include <functional>
 #include <QtCore/QtGlobal>
 #include <QtNetwork/QLocalSocket>
 
@@ -85,7 +86,7 @@ public:
      * Usually 4*timeout would be the worst case (fail) scenario.
      * @see See the corresponding QAPPLICATION_CLASS constructor for reference
      */
-    explicit SingleApplication( int &argc, char *argv[], bool allowSecondary = false, Options options = Mode::User, int timeout = 1000 );
+    explicit SingleApplication( int &argc, char *argv[], bool allowSecondary = false, Options options = Mode::User, int timeout = 1000, std::function<void()> instanceAbortedFunction = Q_NULLPTR );
     ~SingleApplication();
 
     /**


### PR DESCRIPTION
This is convenient if you want to show a message in the 2nd instance that will be aborted because another  instance was already started.