### PR TITLE
Fixed naming clash with QObject which caused QQmlApplicationEngine to crash

### DIFF
--- a/singleapplication.cpp
+++ b/singleapplication.cpp
@@ -37,7 +37,7 @@
  * @param {bool} allowSecondaryInstances
  */
 SingleApplication::SingleApplication( int &argc, char *argv[], bool allowSecondary, Options options, int timeout )
-    : app_t( argc, argv ), d_ptr( new SingleApplicationPrivate( this ) )
+    : app_t( argc, argv ), dd_ptr( new SingleApplicationPrivate( this ) )
 {
     Q_D(SingleApplication);
 

--- a/singleapplication.h
+++ b/singleapplication.h
@@ -126,8 +126,8 @@ Q_SIGNALS:
     void receivedMessage( quint32 instanceId, QByteArray message );
 
 private:
-    SingleApplicationPrivate *d_ptr;
-    Q_DECLARE_PRIVATE(SingleApplication)
+    SingleApplicationPrivate *dd_ptr;
+    Q_DECLARE_PRIVATE_D(dd_ptr, SingleApplication)
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(SingleApplication::Options)


### PR DESCRIPTION
The `d_ptr` variable name clashes with a QObject member. This causes QQmlApplicationEngine to crash during construction. Refactoring its name fixes the crash.

Example:
```
#include <QGuiApplication>
#include <QQmlApplicationEngine>
#include "singleapplication.h"

int main(int argc, char *argv[])
{
    SingleApplication app(argc, argv);
    QQmlApplicationEngine engine("main.qml"); // <-- crashes on construction
    return app.exec();
}
```