### PR TITLE
Allow QObject as base class for SingleApplication

### DIFF
--- a/singleapplication.cpp
+++ b/singleapplication.cpp
@@ -37,9 +37,19 @@
  * @param {bool} allowSecondaryInstances
  */
 SingleApplication::SingleApplication( int &argc, char *argv[], bool allowSecondary, Options options, int timeout )
-    : app_t( argc, argv ), d_ptr( new SingleApplicationPrivate( this ) )
+#ifdef BASE_QOBJECT
+    : QObject()
+#else
+    : app_t( argc, argv )
+#endif
+    , d_ptr( new SingleApplicationPrivate( this ) )
 {
     Q_D(SingleApplication);
+
+#ifdef BASE_QOBJECT
+    Q_UNUSED(argc);
+    Q_UNUSED(argv);
+#endif
 
     // Store the current mode of the program
     d->options = options;

--- a/singleapplication.h
+++ b/singleapplication.h
@@ -27,7 +27,11 @@
 #include <QtNetwork/QLocalSocket>
 
 #ifndef QAPPLICATION_CLASS
+  #define BASE_QOBJECT
+  #define BASE_CLASS QObject
   #define QAPPLICATION_CLASS QCoreApplication
+#else
+  #define BASE_CLASS QAPPLICATION_CLASS
 #endif
 
 #include QT_STRINGIFY(QAPPLICATION_CLASS)
@@ -39,7 +43,7 @@ class SingleApplicationPrivate;
  * Application
  * @see QCoreApplication
  */
-class SingleApplication : public QAPPLICATION_CLASS
+class SingleApplication : public BASE_CLASS
 {
     Q_OBJECT
 

--- a/singleapplication_p.cpp
+++ b/singleapplication_p.cpp
@@ -144,8 +144,6 @@ void SingleApplicationPrivate::initializeMemoryBlock()
 
 void SingleApplicationPrivate::startPrimary()
 {
-    Q_Q(SingleApplication);
-
     // Successful creation means that no main process exists
     // So we start a QLocalServer to listen for connections
     QLocalServer::removeServer( blockServerName );
@@ -171,7 +169,7 @@ void SingleApplicationPrivate::startPrimary()
     InstancesInfo* inst = static_cast <InstancesInfo*>( memory->data() );
 
     inst->primary = true;
-    inst->primaryPid = q->applicationPid();
+    inst->primaryPid = SingleApplication::app_t::instance()->applicationPid();
     inst->checksum = blockChecksum();
 
     instanceNumber = 0;


### PR DESCRIPTION
This allows SingleApplication to be used in template classes, and the application type (Core, Gui, etc) to be selected easier at runtime.

For example:
```
template<typename t_app>
class SingleApplicationT : public t_app
{
public:
    explicit SingleApplicationT(int &argc, char *argv[], bool allowSecondary = false, SingleApplication::Options options = SingleApplication::User, int timeout = 1000)
        : t_app(argc, argv)
        , lock(new SingleApplication(argc, argv, allowSecondary, options, timeout))
    {}
    ~SingleApplicationT()
    {
        delete lock;
    }

    SingleApplication *lock = nullptr;
};
```
And can be used like this:
```
    SingleApplicationT<QCoreApplication> app(argc, argv);
    qDebug() << "process started, pid:" << QCoreApplication::applicationPid();

    QTimer::singleShot(3000, &app, &QCoreApplication::quit);
```

Another example:
```
template<typename t_app>
class SingleApplicationT : public t_app, public SingleApplication
{
public:
    explicit SingleApplicationT(int &argc, char *argv[], bool allowSecondary = false, SingleApplication::Options options = SingleApplication::User, int timeout = 1000)
        : t_app(argc, argv)
        , SingleApplication(argc, argv, allowSecondary, options, timeout)
    {}
};
```

This has a slight issue with multiple inheritance, so connects work like this:
```
    QTimer::singleShot(3000, static_cast<QCoreApplication*>(&app), &QCoreApplication::quit);
```

Would this be useful to upstream?