### PR TITLE
Fix return value of sendMessage()

### DIFF
--- a/singleapplication.cpp
+++ b/singleapplication.cpp
@@ -168,7 +168,7 @@ bool SingleApplication::sendMessage( QByteArray message, int timeout )
     d->connectToPrimary( timeout,  SingleApplicationPrivate::Reconnect );
 
     d->socket->write( message );
-    bool dataWritten = d->socket->flush();
-    d->socket->waitForBytesWritten( timeout );
+    bool dataWritten = d->socket->waitForBytesWritten( timeout );
+    d->socket->flush();
     return dataWritten;
 }


### PR DESCRIPTION
flush() is non-blocking so it can return false when requiring blocking, see https://doc.qt.io/qt-5/qlocalsocket.html#flush
This means sendMessage() will return to the application with false even though data was actually written in waitForBytesWritten().
You should instead rely on the return value of waitForBytesWritten() since you do that anyway.
Also I don't understand the point of doing fush() before waitForBytesWritten(), so changing the order. Not sure flush is needed at all though.
