### PR TITLE
Added constructor argument to allow custom shared memory id

### DIFF
--- a/singleapplication.cpp
+++ b/singleapplication.cpp
@@ -36,10 +36,12 @@
  * @param argv
  * @param {bool} allowSecondaryInstances
  */
-SingleApplication::SingleApplication( int &argc, char *argv[], bool allowSecondary, Options options, int timeout )
+SingleApplication::SingleApplication( int &argc, char *argv[], bool allowSecondary, Options options, int timeout, const QString& custom )
     : app_t( argc, argv ), d_ptr( new SingleApplicationPrivate( this ) )
 {
     Q_D(SingleApplication);
+
+    d->custom = custom;
 
     // Store the current mode of the program
     d->options = options;

--- a/singleapplication.h
+++ b/singleapplication.h
@@ -75,6 +75,8 @@ public:
      * @arg {Mode} mode - Whether for the SingleApplication block to be applied
      * User wide or System wide.
      * @arg {int} timeout - Timeout to wait in miliseconds.
+     * @arg {QString} custom - Custom data allowing different SingleApplications
+     *                         instances running side by side.
      * @note argc and argv may be changed as Qt removes arguments that it
      * recognizes
      * @note Mode::SecondaryNotification only works if set on both the primary
@@ -85,7 +87,7 @@ public:
      * Usually 4*timeout would be the worst case (fail) scenario.
      * @see See the corresponding QAPPLICATION_CLASS constructor for reference
      */
-    explicit SingleApplication( int &argc, char *argv[], bool allowSecondary = false, Options options = Mode::User, int timeout = 1000 );
+    explicit SingleApplication( int &argc, char *argv[], bool allowSecondary = false, Options options = Mode::User, int timeout = 1000, const QString &custom = "" );
     ~SingleApplication();
 
     /**

--- a/singleapplication_p.cpp
+++ b/singleapplication_p.cpp
@@ -87,6 +87,9 @@ void SingleApplicationPrivate::genBlockServerName()
     appData.addData( SingleApplication::app_t::applicationName().toUtf8() );
     appData.addData( SingleApplication::app_t::organizationName().toUtf8() );
     appData.addData( SingleApplication::app_t::organizationDomain().toUtf8() );
+    if (!custom.isEmpty()) {
+        appData.addData(custom.toUtf8());
+    }
 
     if( ! (options & SingleApplication::Mode::ExcludeAppVersion) ) {
         appData.addData( SingleApplication::app_t::applicationVersion().toUtf8() );

--- a/singleapplication_p.h
+++ b/singleapplication_p.h
@@ -89,6 +89,7 @@ public:
     QString blockServerName;
     SingleApplication::Options options;
     QMap<QLocalSocket*, ConnectionInfo> connectionMap;
+    QString custom;
 
 public Q_SLOTS:
     void slotConnectionEstablished();


### PR DESCRIPTION
Sometimes it is desireable to have multiple SingleApplication running
side by side if they are started with different arguments.