### PR TITLE
Use geteuid and getpwuid to get username on Unix, fallback to environment variable

### DIFF
--- a/singleapplication_p.cpp
+++ b/singleapplication_p.cpp
@@ -33,7 +33,6 @@
 #include <cstddef>
 
 #include <QtCore/QDir>
-#include <QtCore/QProcess>
 #include <QtCore/QByteArray>
 #include <QtCore/QDataStream>
 #include <QtCore/QCryptographicHash>

--- a/singleapplication_p.cpp
+++ b/singleapplication_p.cpp
@@ -35,15 +35,19 @@
 #include <QtCore/QDir>
 #include <QtCore/QProcess>
 #include <QtCore/QByteArray>
-#include <QtCore/QSemaphore>
 #include <QtCore/QDataStream>
-#include <QtCore/QStandardPaths>
 #include <QtCore/QCryptographicHash>
 #include <QtNetwork/QLocalServer>
 #include <QtNetwork/QLocalSocket>
 
 #include "singleapplication.h"
 #include "singleapplication_p.h"
+
+#ifdef Q_OS_UNIX
+    #include <unistd.h>
+    #include <sys/types.h>
+    #include <pwd.h>
+#endif
 
 #ifdef Q_OS_WIN
     #include <windows.h>
@@ -109,22 +113,22 @@ void SingleApplicationPrivate::genBlockServerName()
         if( GetUserNameW( username, &usernameLength ) ) {
             appData.addData( QString::fromWCharArray(username).toUtf8() );
         } else {
-            appData.addData( QStandardPaths::standardLocations( QStandardPaths::HomeLocation ).join("").toUtf8() );
+            appData.addData( qgetenv("USERNAME") );
         }
 #endif
 #ifdef Q_OS_UNIX
-        QProcess process;
-        process.start( "whoami" );
-        if( process.waitForFinished( 100 ) &&
-            process.exitCode() == QProcess::NormalExit) {
-            appData.addData( process.readLine() );
-        } else {
-            appData.addData(
-                QDir(
-                    QStandardPaths::standardLocations( QStandardPaths::HomeLocation ).first()
-                ).absolutePath().toUtf8()
-            );
+        QByteArray username;
+        uid_t uid = geteuid();
+        if( uid != -1 ) {
+            struct passwd *pw = getpwuid(uid);
+            if( pw ) {
+                username = pw->pw_name;
+            }
         }
+        if( username.isEmpty() ) {
+            username = qgetenv("USER");
+        }
+        appData.addData(username);
 #endif
     }
 


### PR DESCRIPTION
1. This is faster, using a command is slow and can easily timeout
2. You already use native functions for Windows
3. It compiles on Linux, macOS and openBSD (I've tested all 3)

The fallback using the variable is very unlikely to occur the way it is now, but using the home directory is a bad idea for both for UNIX systems and Windows, because the home folder can differ from the username. The current approach for unix is to timeout if whoami takes to long, so if a user starts the application twice, one of the instances can timeout and the application will be started twice if the home folder is different from the username.
Also removed QSemaphore since it's not needed.
