### PR TITLE
Fix compilation warning/error

### DIFF
--- a/singleapplication_p.cpp
+++ b/singleapplication_p.cpp
@@ -118,11 +118,9 @@ void SingleApplicationPrivate::genBlockServerName()
 #ifdef Q_OS_UNIX
         QByteArray username;
         uid_t uid = geteuid();
-        if( uid != -1 ) {
-            struct passwd *pw = getpwuid(uid);
-            if( pw ) {
-                username = pw->pw_name;
-            }
+        struct passwd *pw = getpwuid(uid);
+        if( pw ) {
+            username = pw->pw_name;
         }
         if( username.isEmpty() ) {
             username = qgetenv("USER");


### PR DESCRIPTION
Fix `comparison between signed and unsigned integer expressions` problem.
User ID is a positive integer  in Linux/UNIX(macOS, FreeBSD, Solaris), also `geteuid()` never fails with return code.