### PR TITLE
Fix qsrand/qrand and QTime::elapsed deprication in Qt 5.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,3 +275,4 @@ License
 This library and it's supporting documentation are released under
 `The MIT License (MIT)` with the exception of the Qt calculator examples which
 is distributed under the BSD license.
+


### PR DESCRIPTION
Replace functions deprecated in Qt 5.14. Fixes both #81 and #83.
I've left qrand-based code for builds with Qt 5.9 LTS that is shipped with some Linux distributions.