### PR TITLE
feat: Add a function to check if the instance is the only instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,13 @@ Returns if the instance is a secondary instance.
 ---
 
 ```cpp
+bool SingleApplication::isSingleInstance()
+```
+Returns if the instance is the only running instance.
+
+---
+
+```cpp
 quint32 SingleApplication::instanceId()
 ```
 

--- a/singleapplication.cpp
+++ b/singleapplication.cpp
@@ -160,6 +160,31 @@ bool SingleApplication::isSecondary()
     return d->server == nullptr;
 }
 
+bool SingleApplication::isSingleInstance()
+{
+    Q_D(SingleApplication);
+
+    InstancesInfo backup = *static_cast<InstancesInfo*>( d->memory->data() );
+
+    d->memory->detach();
+
+    if ( d->memory->create( sizeof( InstancesInfo ) ) ) {
+        d->memory->lock();
+        *static_cast<InstancesInfo*>( d->memory->data() ) = backup;
+        d->memory->unlock();
+        return true;
+    }
+
+    if( ! d->memory->attach() ) {
+        qCritical() << "SingleApplication: Unable to attach to shared memory block.";
+        qCritical() << d->memory->errorString();
+        delete d;
+        ::exit( EXIT_FAILURE );
+    }
+
+    return false;
+}
+
 quint32 SingleApplication::instanceId()
 {
     Q_D(SingleApplication);

--- a/singleapplication.h
+++ b/singleapplication.h
@@ -101,6 +101,12 @@ public:
     bool isSecondary();
 
     /**
+     * @brief Check if the instance is the only running instance.
+     * @returns {bool}
+     */
+    bool isSingleInstance();
+
+    /**
      * @brief Returns a unique identifier for the current instance
      * @returns {qint32}
      */


### PR DESCRIPTION
The function: bool SingleApplication::isSingleInstance()
Returns if the instance is the only running instance.

It is hard to check the number of running instances after a crash,
so this is an alternative solution for #89.

It uses a trick: the shared memory will be released after the last
instance detaches from it.

This closes #89.