### PR TITLE
fixed CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,8 @@ elseif(QAPPLICATION_CLASS STREQUAL QGuiApplication)
 else()
     find_package(Qt5 COMPONENTS Core REQUIRED)
 endif()
-add_compile_definitions(QAPPLICATION_CLASS=${QAPPLICATION_CLASS})
+target_compile_definitions(${PROJECT_NAME} PRIVATE QAPPLICATION_CLASS=${QAPPLICATION_CLASS})
+
 
 # Link dependencies
 target_link_libraries(${PROJECT_NAME} PRIVATE Qt5::Network)


### PR DESCRIPTION
With using PUBLIC instead of PRIVATE we only need to set:

```
set(QAPPLICATION_CLASS "QApplication" CACHE INTERNAL "Inheritance class for SingleApplication")
```

In our project and not also:

```
target_compile_definitions(${PROJECT_NAME} PUBLIC QAPPLICATION_CLASS=${QAPPLICATION_CLASS}) 
```

Which is what we think a sane default.

Downside: we have now a global DEFINE polluting the namespace. What do you think?