### PR TITLE
Fix a crash when exiting an application on Android and iOS

### DIFF
--- a/singleapplication.cpp
+++ b/singleapplication.cpp
@@ -48,7 +48,7 @@ SingleApplication::SingleApplication( int &argc, char *argv[], bool allowSeconda
 #if defined(Q_OS_ANDROID) || defined(Q_OS_IOS)
     // On Android and iOS since the library is not supported fallback to
     // standard QApplication behaviour by simply returning at this point.
-    qWarning() << "SingleApplication is not supported on Android and iOS systems.";
+    qDebug() << "SingleApplication is not supported on Android and iOS systems.";
     return;
 #endif
 

--- a/singleapplication_p.cpp
+++ b/singleapplication_p.cpp
@@ -69,19 +69,21 @@ SingleApplicationPrivate::~SingleApplicationPrivate()
         delete socket;
     }
 
-    memory->lock();
-    InstancesInfo* inst = static_cast<InstancesInfo*>(memory->data());
-    if( server != nullptr ) {
-        server->close();
-        delete server;
-        inst->primary = false;
-        inst->primaryPid = -1;
-        inst->primaryUser[0] =  '\0';
-        inst->checksum = blockChecksum();
-    }
-    memory->unlock();
+    if( memory != nullptr ) {
+        memory->lock();
+        InstancesInfo* inst = static_cast<InstancesInfo*>(memory->data());
+        if( server != nullptr ) {
+            server->close();
+            delete server;
+            inst->primary = false;
+            inst->primaryPid = -1;
+            inst->primaryUser[0] =  '\0';
+            inst->checksum = blockChecksum();
+        }
+        memory->unlock();
 
-    delete memory;
+        delete memory;
+    }
 }
 
 QString SingleApplicationPrivate::getUsername()


### PR DESCRIPTION
memory is never created when starting on Android and iOS, but the destructor still tries to destroy it.