### PR TITLE
Improve CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,43 +1,33 @@
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.7.0)
 
-project(SingleApplication)
+project(SingleApplication LANGUAGES CXX)
 
-set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
 
-# SingleApplication base class
-set(QAPPLICATION_CLASS QCoreApplication CACHE STRING "Inheritance class for SingleApplication")
-set_property(CACHE QAPPLICATION_CLASS PROPERTY STRINGS QApplication QGuiApplication QCoreApplication)
-
-# Libary target
 add_library(${PROJECT_NAME} STATIC
     singleapplication.cpp
     singleapplication_p.cpp
-    )
+)
 
 # Find dependencies
-find_package(Qt5Network)
+find_package(Qt5 COMPONENTS Network REQUIRED)
+target_link_libraries(${PROJECT_NAME} PRIVATE Qt5::Network)
+
 if(QAPPLICATION_CLASS STREQUAL QApplication)
     find_package(Qt5 COMPONENTS Widgets REQUIRED)
+    target_link_libraries(${PROJECT_NAME} PUBLIC Qt5::Widgets)
 elseif(QAPPLICATION_CLASS STREQUAL QGuiApplication)
     find_package(Qt5 COMPONENTS Gui REQUIRED)
+    target_link_libraries(${PROJECT_NAME} PUBLIC Qt5::Gui)
 else()
+    set(QAPPLICATION_CLASS QCoreApplication)
     find_package(Qt5 COMPONENTS Core REQUIRED)
-endif()
-add_compile_definitions(QAPPLICATION_CLASS=${QAPPLICATION_CLASS})
-
-# Link dependencies
-target_link_libraries(${PROJECT_NAME} PRIVATE Qt5::Network)
-if(QAPPLICATION_CLASS STREQUAL QApplication)
-    target_link_libraries(${PROJECT_NAME} PRIVATE Qt5::Widgets)
-elseif(QAPPLICATION_CLASS STREQUAL QGuiApplication)
-    target_link_libraries(${PROJECT_NAME} PRIVATE Qt5::Gui)
-else()
-    target_link_libraries(${PROJECT_NAME} PRIVATE Qt5::Core)
+    target_link_libraries(${PROJECT_NAME} PUBLIC Qt5::Core)
 endif()
 
 if(WIN32)
     target_link_libraries(${PROJECT_NAME} PRIVATE advapi32)
 endif()
 
+target_compile_definitions(${PROJECT_NAME} PUBLIC QAPPLICATION_CLASS=${QAPPLICATION_CLASS})
 target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
1. Do not set `QAPPLICATION_CLASS` directly.
2. Use `target_compile_definitions` instead of `add_compile_definitions`.
3. Specify `CXX` directly to reduce configuration time.
4. Simplify syntax.
5. Use correct minimum required version.