### PR TITLE
Update CMake examples

### DIFF
--- a/examples/basic/CMakeLists.txt
+++ b/examples/basic/CMakeLists.txt
@@ -1,15 +1,13 @@
 cmake_minimum_required(VERSION 3.1.0)
 
-project(basic)
+project(basic LANGUAGES CXX)
 
 # SingleApplication base class
-set(QAPPLICATION_CLASS QCoreApplication CACHE STRING "Inheritance class for SingleApplication")
+set(QAPPLICATION_CLASS QCoreApplication)
 
-add_executable(basic
-    main.cpp
-    )
+add_executable(basic main.cpp)
 
 find_package(Qt5 COMPONENTS Core REQUIRED)
 add_subdirectory(../.. SingleApplication)
-target_link_libraries(${PROJECT_NAME} Qt5::Core SingleApplication)
+target_link_libraries(${PROJECT_NAME} SingleApplication)
 

--- a/examples/calculator/CMakeLists.txt
+++ b/examples/calculator/CMakeLists.txt
@@ -1,11 +1,11 @@
 cmake_minimum_required(VERSION 3.1.0)
 
-project(calculator)
+project(calculator LANGUAGES CXX)
 
 set(CMAKE_AUTOMOC ON)
 
 # SingleApplication base class
-set(QAPPLICATION_CLASS QApplication CACHE STRING "Inheritance class for SingleApplication")
+set(QAPPLICATION_CLASS QApplication)
 
 add_executable(${PROJECT_NAME}
     button.h
@@ -13,8 +13,8 @@ add_executable(${PROJECT_NAME}
     button.cpp
     calculator.cpp
     main.cpp
-    )
+)
 
 find_package(Qt5 COMPONENTS Widgets REQUIRED)
 add_subdirectory(../.. SingleApplication)
-target_link_libraries(${PROJECT_NAME} Qt5::Widgets SingleApplication)
+target_link_libraries(${PROJECT_NAME} SingleApplication)

--- a/examples/sending_arguments/CMakeLists.txt
+++ b/examples/sending_arguments/CMakeLists.txt
@@ -1,19 +1,19 @@
 cmake_minimum_required(VERSION 3.1.0)
 
-project(sending_arguments)
+project(sending_arguments LANGUAGES CXX)
 
 set(CMAKE_AUTOMOC ON)
 
 # SingleApplication base class
-set(QAPPLICATION_CLASS QCoreApplication CACHE STRING "Inheritance class for SingleApplication")
+set(QAPPLICATION_CLASS QCoreApplication)
 
 add_executable(${PROJECT_NAME}
     main.cpp
     messagereceiver.cpp
     messagereceiver.h
     main.cpp
-    )
+)
 
 find_package(Qt5 COMPONENTS Core REQUIRED)
 add_subdirectory(../.. SingleApplication)
-target_link_libraries(${PROJECT_NAME} Qt5::Core SingleApplication)
+target_link_libraries(${PROJECT_NAME} SingleApplication)


### PR DESCRIPTION
I updated examples to the latest changes in CMake.

1. No longer need to link Qt::Widgets and Qt::Core libraries.
2. Set languages explicitly to reduce CMake configuration time.
3. Do not store `QAPPLICATION_CLASS` in cache.