### PR TITLE
Fix Clang Tidy warnings

### DIFF
--- a/singleapplication.cpp
+++ b/singleapplication.cpp
@@ -85,7 +85,7 @@ SingleApplication::SingleApplication( int &argc, char *argv[], bool allowSeconda
         }
     }
 
-    InstancesInfo* inst = static_cast<InstancesInfo*>( d->memory->data() );
+    auto *inst = static_cast<InstancesInfo*>( d->memory->data() );
     QElapsedTimer time;
     time.start();
 
@@ -184,7 +184,7 @@ QString SingleApplication::currentUser()
     return d->getUsername();
 }
 
-bool SingleApplication::sendMessage( QByteArray message, int timeout )
+bool SingleApplication::sendMessage( const QByteArray &message, int timeout )
 {
     Q_D(SingleApplication);
 

--- a/singleapplication.h
+++ b/singleapplication.h
@@ -43,7 +43,7 @@ class SingleApplication : public QAPPLICATION_CLASS
 {
     Q_OBJECT
 
-    typedef QAPPLICATION_CLASS app_t;
+    using app_t = QAPPLICATION_CLASS;
 
 public:
     /**
@@ -86,7 +86,7 @@ public:
      * @see See the corresponding QAPPLICATION_CLASS constructor for reference
      */
     explicit SingleApplication( int &argc, char *argv[], bool allowSecondary = false, Options options = Mode::User, int timeout = 1000 );
-    ~SingleApplication();
+    ~SingleApplication() override;
 
     /**
      * @brief Returns if the instance is the primary instance
@@ -131,7 +131,7 @@ public:
      * @note sendMessage() will return false if invoked from the primary
      * instance.
      */
-    bool sendMessage( QByteArray message, int timeout = 100 );
+    bool sendMessage( const QByteArray &message, int timeout = 100 );
 
 Q_SIGNALS:
     void instanceStarted();

--- a/singleapplication_p.cpp
+++ b/singleapplication_p.cpp
@@ -71,7 +71,7 @@ SingleApplicationPrivate::~SingleApplicationPrivate()
 
     if( memory != nullptr ) {
         memory->lock();
-        InstancesInfo* inst = static_cast<InstancesInfo*>(memory->data());
+        auto *inst = static_cast<InstancesInfo*>(memory->data());
         if( server != nullptr ) {
             server->close();
             delete server;
@@ -149,7 +149,7 @@ void SingleApplicationPrivate::genBlockServerName()
 
 void SingleApplicationPrivate::initializeMemoryBlock()
 {
-    InstancesInfo* inst = static_cast<InstancesInfo*>( memory->data() );
+    auto *inst = static_cast<InstancesInfo*>( memory->data() );
     inst->primary = false;
     inst->secondary = 0;
     inst->primaryPid = -1;
@@ -183,7 +183,7 @@ void SingleApplicationPrivate::startPrimary()
     );
 
     // Reset the number of connections
-    InstancesInfo* inst = static_cast <InstancesInfo*>( memory->data() );
+    auto *inst = static_cast <InstancesInfo*>( memory->data() );
 
     inst->primary = true;
     inst->primaryPid = q->applicationPid();
@@ -266,7 +266,7 @@ qint64 SingleApplicationPrivate::primaryPid()
     qint64 pid;
 
     memory->lock();
-    InstancesInfo* inst = static_cast<InstancesInfo*>( memory->data() );
+    auto *inst = static_cast<InstancesInfo*>( memory->data() );
     pid = inst->primaryPid;
     memory->unlock();
 
@@ -278,7 +278,7 @@ QString SingleApplicationPrivate::primaryUser()
     QByteArray username;
 
     memory->lock();
-    InstancesInfo* inst = static_cast<InstancesInfo*>( memory->data() );
+    auto *inst = static_cast<InstancesInfo*>( memory->data() );
     username = inst->primaryUser;
     memory->unlock();
 

--- a/singleapplication_p.h
+++ b/singleapplication_p.h
@@ -46,11 +46,9 @@ struct InstancesInfo {
 };
 
 struct ConnectionInfo {
-    explicit ConnectionInfo() :
-        msgLen(0), instanceId(0), stage(0) {}
-    qint64 msgLen;
-    quint32 instanceId;
-    quint8 stage;
+    qint64 msgLen = 0;
+    quint32 instanceId = 0;
+    quint8 stage = 0;
 };
 
 class SingleApplicationPrivate : public QObject {
@@ -70,7 +68,7 @@ public:
     Q_DECLARE_PUBLIC(SingleApplication)
 
     SingleApplicationPrivate( SingleApplication *q_ptr );
-    ~SingleApplicationPrivate();
+    ~SingleApplicationPrivate() override;
 
     QString getUsername();
     void genBlockServerName();


### PR DESCRIPTION
I integrated Clang Tidy in my project and noticed that it produce some warnings. I decided to fix it instead of ignore library folder. I fixed the following:
[modernize-use-override](https://clang.llvm.org/extra/clang-tidy/checks/modernize-use-override.html#modernize-use-override)
[modernize-use-auto](https://clang.llvm.org/extra/clang-tidy/checks/modernize-use-auto.html)
[modernize-use-using](https://clang.llvm.org/extra/clang-tidy/checks/modernize-use-using.html)
[performance-unnecessary-value-param](https://clang.llvm.org/extra/clang-tidy/checks/performance-unnecessary-value-param.html)
[modernize-use-default-member-init](https://clang.llvm.org/extra/clang-tidy/checks/modernize-use-default-member-init.html)