### PR TITLE
Add library alias for CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ add_library(${PROJECT_NAME} STATIC
     singleapplication.cpp
     singleapplication_p.cpp
 )
+add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
 # Find dependencies
 find_package(Qt5 COMPONENTS Network REQUIRED)

--- a/examples/basic/CMakeLists.txt
+++ b/examples/basic/CMakeLists.txt
@@ -9,5 +9,5 @@ add_executable(basic main.cpp)
 
 find_package(Qt5 COMPONENTS Core REQUIRED)
 add_subdirectory(../.. SingleApplication)
-target_link_libraries(${PROJECT_NAME} SingleApplication)
+target_link_libraries(${PROJECT_NAME} SingleApplication::SingleApplication)
 

--- a/examples/calculator/CMakeLists.txt
+++ b/examples/calculator/CMakeLists.txt
@@ -17,4 +17,4 @@ add_executable(${PROJECT_NAME}
 
 find_package(Qt5 COMPONENTS Widgets REQUIRED)
 add_subdirectory(../.. SingleApplication)
-target_link_libraries(${PROJECT_NAME} SingleApplication)
+target_link_libraries(${PROJECT_NAME} SingleApplication::SingleApplication)

--- a/examples/sending_arguments/CMakeLists.txt
+++ b/examples/sending_arguments/CMakeLists.txt
@@ -16,4 +16,4 @@ add_executable(${PROJECT_NAME}
 
 find_package(Qt5 COMPONENTS Core REQUIRED)
 add_subdirectory(../.. SingleApplication)
-target_link_libraries(${PROJECT_NAME} SingleApplication)
+target_link_libraries(${PROJECT_NAME} SingleApplication::SingleApplication)


### PR DESCRIPTION
In CMake it's common to add such alternative naming for third-party libraries (like in Qt). So I added `SingleApplication::SingleApplication` for consistency with other projects (yes, it's common to use name twice for single module libraries).