### PR TITLE
Use qstrncpy

### DIFF
--- a/singleapplication_p.cpp
+++ b/singleapplication_p.cpp
@@ -187,8 +187,7 @@ void SingleApplicationPrivate::startPrimary()
 
     inst->primary = true;
     inst->primaryPid = q->applicationPid();
-    strncpy( inst->primaryUser, getUsername().toUtf8().data(), 127 );
-    inst->primaryUser[127] = '\0';
+    qstrncpy( inst->primaryUser, getUsername().toUtf8().data(), sizeof(inst->primaryUser) );
     inst->checksum = blockChecksum();
 
     instanceNumber = 0;


### PR DESCRIPTION
Fixes MSVC [C4996](https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4996?view=vs-2019) warning (it suggests to use not portable `strncpy_s`).
Also [qstrncpy](https://doc-snapshots.qt.io/qt5-5.12/qbytearray.html#qstrncpy) guarantees that `inst->primaryUser` will be '\0'-terminated