### PR TITLE
fixed build with Qt 5.9 MSVC2017

### DIFF
--- a/singleapplication_p.cpp
+++ b/singleapplication_p.cpp
@@ -57,6 +57,7 @@
 #endif
 
 #ifdef Q_OS_WIN
+    #define NOMINMAX
     #include <windows.h>
     #include <lmcons.h>
 #endif


### PR DESCRIPTION
define NOMINMAX before <Windows.h> inclusion to disable min/max macros
defined in it. these macros conflict with any min/max functions and it
is common practice to disable them adding NOMINMAX define.

see https://ci.appveyor.com/project/Kolcha/digitalclock4/build/job/9ikv6q2uwnomj3s1#L305 for details