### PR TITLE
Fix return value of connectToPrimary() when connect is successful

### DIFF
--- a/singleapplication_p.cpp
+++ b/singleapplication_p.cpp
@@ -267,10 +267,9 @@ bool SingleApplicationPrivate::connectToPrimary( int timeout, ConnectionType con
 
     socket->write( header );
     socket->write( initMsg );
+    bool result = socket->waitForBytesWritten( timeout - time.elapsed() );
     socket->flush();
-    if( socket->waitForBytesWritten( timeout - time.elapsed() )) return true;
-
-    return false;
+    return result;
 }
 
 quint16 SingleApplicationPrivate::blockChecksum()


### PR DESCRIPTION
Calling flush() after write() makes waitForBytesWritten() always return false so the connect is never successful and message is never sent to the primary in sendMessage().
You broke this in https://github.com/itay-grudev/SingleApplication/commit/3e83f5ce13c06bf6c65fb369d152cd570d718bcb
This is a similar bug to what I've fixed previously.
In general I don't think it's a good practice to release a new version the same day you make such huge changes, it would be better to allow at least a couple of days for testing.
