### PR TITLE
Fix build issue with MinGW GCC pedantic mode

### DIFF
--- a/singleapplication_p.cpp
+++ b/singleapplication_p.cpp
@@ -57,7 +57,9 @@
 #endif
 
 #ifdef Q_OS_WIN
-    #define NOMINMAX
+    #ifndef NOMINMAX
+        #define NOMINMAX 1
+    #endif
     #include <windows.h>
     #include <lmcons.h>
 #endif


### PR DESCRIPTION
Without guard this define from https://github.com/itay-grudev/SingleApplication/commit/3230430311c3b9d027a0ef23c3657eed3caaa696#diff-35c7c4188004bde084344a3aa8eeab6dR60 introduced compilation warning/error, and can break compilation