### PR TITLE
Fix conversion from int to quint32

### DIFF
--- a/.github/workflows/build-cmake.yml
+++ b/.github/workflows/build-cmake.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Install Qt
-      uses: jurplel/install-qt-action@v2
+      uses: jurplel/install-qt-action@v2.9.0
       with:
         version: ${{ matrix.qt_version }}
 

--- a/singleapplication_p.cpp
+++ b/singleapplication_p.cpp
@@ -233,7 +233,7 @@ bool SingleApplicationPrivate::connectToPrimary( int timeout, ConnectionType con
             socket->connectToServer( blockServerName );
 
           if( socket->state() == QLocalSocket::ConnectingState ){
-              socket->waitForConnected( timeout - time.elapsed() );
+              socket->waitForConnected( static_cast<int>(timeout - time.elapsed()) );
           }
 
           // If connected break out of the loop
@@ -269,7 +269,7 @@ bool SingleApplicationPrivate::connectToPrimary( int timeout, ConnectionType con
 
     socket->write( header );
     socket->write( initMsg );
-    bool result = socket->waitForBytesWritten( timeout - time.elapsed() );
+    bool result = socket->waitForBytesWritten( static_cast<int>(timeout - time.elapsed()) );
     socket->flush();
     return result;
 }

--- a/singleapplication_p.cpp
+++ b/singleapplication_p.cpp
@@ -70,7 +70,7 @@ SingleApplicationPrivate::SingleApplicationPrivate( SingleApplication *q_ptr )
     server = nullptr;
     socket = nullptr;
     memory = nullptr;
-    instanceNumber = -1;
+    instanceNumber = 0;
 }
 
 SingleApplicationPrivate::~SingleApplicationPrivate()


### PR DESCRIPTION
This PR fixes warning which comes from MSVC. `instanceNumber` is unsigned, so it can't be equal to `-1`.

If you apply this change, could you please draft a new minor release? I use [FetchContent](https://github.com/crow-translate/crow-translate/blob/master/cmake/ExternalLibraries.cmake) in CMake and it would be nice to point stable release instead of specific commit.