### PR TITLE
Fix Clang Tidy warnings

### DIFF
--- a/singleapplication.cpp
+++ b/singleapplication.cpp
@@ -57,7 +57,7 @@ SingleApplication::SingleApplication( int &argc, char *argv[], bool allowSeconda
 
     // To mitigate QSharedMemory issues with large amount of processes
     // attempting to attach at the same time
-    d->randomSleep();
+    SingleApplicationPrivate::randomSleep();
 
 #ifdef Q_OS_UNIX
     // By explicitly attaching it and then deleting it we make sure that the
@@ -117,7 +117,7 @@ SingleApplication::SingleApplication( int &argc, char *argv[], bool allowSeconda
         qDebug() << "SingleApplication: Unable to unlock memory for random wait.";
         qDebug() << d->memory->errorString();
       }
-      d->randomSleep();
+      SingleApplicationPrivate::randomSleep();
       if( ! d->memory->lock() ){
         qCritical() << "SingleApplication: Unable to lock memory after random wait.";
         abortSafely();
@@ -225,7 +225,7 @@ QString SingleApplication::primaryUser()
 QString SingleApplication::currentUser()
 {
     Q_D( SingleApplication );
-    return d->getUsername();
+    return SingleApplicationPrivate::getUsername();
 }
 
 /**

--- a/singleapplication.cpp
+++ b/singleapplication.cpp
@@ -224,7 +224,6 @@ QString SingleApplication::primaryUser()
  */
 QString SingleApplication::currentUser()
 {
-    Q_D( SingleApplication );
     return SingleApplicationPrivate::getUsername();
 }
 

--- a/singleapplication_p.cpp
+++ b/singleapplication_p.cpp
@@ -170,8 +170,6 @@ void SingleApplicationPrivate::initializeMemoryBlock() const
 
 void SingleApplicationPrivate::startPrimary()
 {
-    Q_Q(SingleApplication);
-
     // Reset the number of connections
     auto *inst = static_cast <InstancesInfo*>( memory->data() );
 

--- a/singleapplication_p.cpp
+++ b/singleapplication_p.cpp
@@ -158,7 +158,7 @@ void SingleApplicationPrivate::genBlockServerName()
     blockServerName = appData.result().toBase64().replace("/", "_");
 }
 
-void SingleApplicationPrivate::initializeMemoryBlock()
+void SingleApplicationPrivate::initializeMemoryBlock() const
 {
     auto *inst = static_cast<InstancesInfo*>( memory->data() );
     inst->primary = false;
@@ -176,7 +176,7 @@ void SingleApplicationPrivate::startPrimary()
     auto *inst = static_cast <InstancesInfo*>( memory->data() );
 
     inst->primary = true;
-    inst->primaryPid = q->applicationPid();
+    inst->primaryPid = QCoreApplication::applicationPid();
     qstrncpy( inst->primaryUser, getUsername().toUtf8().data(), sizeof(inst->primaryUser) );
     inst->checksum = blockChecksum();
     instanceNumber = 0;
@@ -211,7 +211,7 @@ void SingleApplicationPrivate::startSecondary()
   instanceNumber = inst->secondary;
 }
 
-bool SingleApplicationPrivate::connectToPrimary( int timeout, ConnectionType connectionType )
+bool SingleApplicationPrivate::connectToPrimary( int msecs, ConnectionType connectionType )
 {
     QElapsedTimer time;
     time.start();
@@ -233,14 +233,14 @@ bool SingleApplicationPrivate::connectToPrimary( int timeout, ConnectionType con
             socket->connectToServer( blockServerName );
 
           if( socket->state() == QLocalSocket::ConnectingState ){
-              socket->waitForConnected( static_cast<int>(timeout - time.elapsed()) );
+              socket->waitForConnected( static_cast<int>(msecs - time.elapsed()) );
           }
 
           // If connected break out of the loop
           if( socket->state() == QLocalSocket::ConnectedState ) break;
 
           // If elapsed time since start is longer than the method timeout return
-          if( time.elapsed() >= timeout ) return false;
+          if( time.elapsed() >= msecs ) return false;
         }
     }
 
@@ -269,12 +269,12 @@ bool SingleApplicationPrivate::connectToPrimary( int timeout, ConnectionType con
 
     socket->write( header );
     socket->write( initMsg );
-    bool result = socket->waitForBytesWritten( static_cast<int>(timeout - time.elapsed()) );
+    bool result = socket->waitForBytesWritten( static_cast<int>(msecs - time.elapsed()) );
     socket->flush();
     return result;
 }
 
-quint16 SingleApplicationPrivate::blockChecksum()
+quint16 SingleApplicationPrivate::blockChecksum() const
 {
     return qChecksum(
        static_cast <const char *>( memory->data() ),
@@ -282,7 +282,7 @@ quint16 SingleApplicationPrivate::blockChecksum()
    );
 }
 
-qint64 SingleApplicationPrivate::primaryPid()
+qint64 SingleApplicationPrivate::primaryPid() const
 {
     qint64 pid;
 
@@ -294,7 +294,7 @@ qint64 SingleApplicationPrivate::primaryPid()
     return pid;
 }
 
-QString SingleApplicationPrivate::primaryUser()
+QString SingleApplicationPrivate::primaryUser() const
 {
     QByteArray username;
 

--- a/singleapplication_p.h
+++ b/singleapplication_p.h
@@ -70,18 +70,18 @@ public:
     SingleApplicationPrivate( SingleApplication *q_ptr );
     ~SingleApplicationPrivate() override;
 
-    QString getUsername();
+    static QString getUsername();
     void genBlockServerName();
-    void initializeMemoryBlock();
+    void initializeMemoryBlock() const;
     void startPrimary();
     void startSecondary();
-    bool connectToPrimary(int msecs, ConnectionType connectionType );
-    quint16 blockChecksum();
-    qint64 primaryPid();
-    QString primaryUser();
+    bool connectToPrimary( int msecs, ConnectionType connectionType );
+    quint16 blockChecksum() const;
+    qint64 primaryPid() const;
+    QString primaryUser() const;
     void readInitMessageHeader(QLocalSocket *socket);
     void readInitMessageBody(QLocalSocket *socket);
-    void randomSleep();
+    static void randomSleep();
 
     SingleApplication *q_ptr;
     QSharedMemory *memory;


### PR DESCRIPTION
I fixed the following Clang Tidy warnings (found on my CI):
[readability-convert-member-functions-to-static](https://clang.llvm.org/extra/clang-tidy/checks/readability-convert-member-functions-to-static.html)
[readability-static-accessed-through-instance](https://clang.llvm.org/extra/clang-tidy/checks/readability-static-accessed-through-instance.html)
[readability-make-member-function-const](https://clang.llvm.org/extra/clang-tidy/checks/readability-make-member-function-const.html)
[readability-inconsistent-declaration-parameter-name](https://clang.llvm.org/extra/clang-tidy/checks/readability-inconsistent-declaration-parameter-name.html)