### PR TITLE
Use const reference and bump GitHub actions

### DIFF
--- a/.github/workflows/build-cmake.yml
+++ b/.github/workflows/build-cmake.yml
@@ -8,11 +8,11 @@ jobs:
     strategy:
       matrix:
         qt_version: [5.12.6, 5.13.2, 5.14.0, 5.15.0, 6.0.0]
-        platform: [ubuntu-latest, windows-latest, macos-latest]
+        platform: [ubuntu-20.04, windows-latest, macos-latest]
         include:
           - qt_version: 6.0.0
             additional_arguments: -D QT_DEFAULT_MAJOR_VERSION=6
-          - platform: ubuntu-latest
+          - platform: ubuntu-20.04
             CXXFLAGS: -Wall -Wextra -pedantic -Werror
           - platform: macos-latest
             CXXFLAGS: -Wall -Wextra -pedantic -Werror

--- a/.github/workflows/build-cmake.yml
+++ b/.github/workflows/build-cmake.yml
@@ -24,10 +24,10 @@ jobs:
       CXXFLAGS: ${{ matrix.CXXFLAGS }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v2.3.4
 
     - name: Install Qt
-      uses: jurplel/install-qt-action@v2.9.0
+      uses: jurplel/install-qt-action@v2.11.1
       with:
         version: ${{ matrix.qt_version }}
 

--- a/singleapplication.cpp
+++ b/singleapplication.cpp
@@ -36,7 +36,7 @@
  * @param options Optional flags to toggle specific behaviour
  * @param timeout Maximum time blocking functions are allowed during app load
  */
-SingleApplication::SingleApplication( int &argc, char *argv[], bool allowSecondary, Options options, int timeout, QString userData )
+SingleApplication::SingleApplication( int &argc, char *argv[], bool allowSecondary, Options options, int timeout, const QString &userData )
     : app_t( argc, argv ), d_ptr( new SingleApplicationPrivate( this ) )
 {
     Q_D( SingleApplication );

--- a/singleapplication.h
+++ b/singleapplication.h
@@ -85,7 +85,7 @@ public:
      * Usually 4*timeout would be the worst case (fail) scenario.
      * @see See the corresponding QAPPLICATION_CLASS constructor for reference
      */
-    explicit SingleApplication( int &argc, char *argv[], bool allowSecondary = false, Options options = Mode::User, int timeout = 1000, QString userData = QString() );
+    explicit SingleApplication( int &argc, char *argv[], bool allowSecondary = false, Options options = Mode::User, int timeout = 1000, const QString &userData = {} );
     ~SingleApplication() override;
 
     /**


### PR DESCRIPTION
In this PR I used const reference to avoid extra copy of `userData`. Also I bumped GitHub actions and set Ubuntu version explicitly (currently `ubuntu-latest` is old `ubuntu-16.04`, [link](https://docs.github.com/en/free-pro-team@latest/actions/reference/specifications-for-github-hosted-runners#supported-runners-and-hardware-resources)) to fix CI issues.