### PR TITLE
Remove ConnectionInfo after socket is destroyed

### DIFF
--- a/singleapplication_p.cpp
+++ b/singleapplication_p.cpp
@@ -331,8 +331,7 @@ void SingleApplicationPrivate::slotConnectionEstablished()
     QObject::connect(nextConnSocket, &QLocalSocket::disconnected, nextConnSocket, &QLocalSocket::deleteLater);
 
     QObject::connect(nextConnSocket, &QLocalSocket::destroyed,
-        [nextConnSocket, this](QObject *obj){
-            Q_UNUSED(obj)
+        [nextConnSocket, this](){
             connectionMap.remove(nextConnSocket);
         }
     );

--- a/singleapplication_p.cpp
+++ b/singleapplication_p.cpp
@@ -328,10 +328,12 @@ void SingleApplicationPrivate::slotConnectionEstablished()
         }
     );
 
-    QObject::connect(nextConnSocket, &QLocalSocket::disconnected,
-        [nextConnSocket, this](){
+    QObject::connect(nextConnSocket, &QLocalSocket::disconnected, nextConnSocket, &QLocalSocket::deleteLater);
+
+    QObject::connect(nextConnSocket, &QLocalSocket::destroyed,
+        [nextConnSocket, this](QObject *obj){
+            Q_UNUSED(obj)
             connectionMap.remove(nextConnSocket);
-            nextConnSocket->deleteLater();
         }
     );
 


### PR DESCRIPTION
As described in https://github.com/itay-grudev/SingleApplication/issues/121#issuecomment-734225947 the socket can still emit a `readyRead()` after `disconnect()` is emitted. This can be seen by adding a bit of debug code to the `disconnect()` signal and also in the `readyRead()` to verify the `ConnectionInfo` is missing. This would cause a new struct to be created, and think that the connection is still at the "Header" stage, which would eat the first 8 bytes of a message being sent.

Instead of removing the `ConnectionInfo` when the socket is disconnected, wait till it is actually destroyed. These changes are far simpler than I had made originally :)

This PR closes #123.