### PR TITLE
Simplify randomSleep() for old Qt version

### DIFF
--- a/singleapplication_p.cpp
+++ b/singleapplication_p.cpp
@@ -471,7 +471,7 @@ void SingleApplicationPrivate::randomSleep()
     QThread::msleep( QRandomGenerator::global()->bounded( 8u, 18u ));
 #else
     qsrand( QDateTime::currentMSecsSinceEpoch() % std::numeric_limits<uint>::max() );
-    QThread::msleep( 8 + static_cast <unsigned long>( static_cast <float>( qrand() ) / RAND_MAX * 10 ));
+    QThread::msleep( qrand() % 11 + 8);
 #endif
 }
 


### PR DESCRIPTION
This simplifies the randomSleep() code and also fixes `implicit conversion from 'int' to 'float' changes value from 2147483647 to 2147483648 [clang-diagnostic-implicit-int-float-conversion]` warning for old Qt versions.