### PR TITLE
Use AppImage path for hash when running as AppImage.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Changelog
 If by accident I have forgotten to credit someone in the CHANGELOG, email me and I will fix it.
 
 
+__3.3.1__
+---------
+
+* Added support for _AppImage_ dynamic executable paths. - _Michael Klein_
+
 __3.3.0__
 ---------
 

--- a/singleapplication_p.cpp
+++ b/singleapplication_p.cpp
@@ -153,7 +153,7 @@ void SingleApplicationPrivate::genBlockServerName()
             appData.addData( SingleApplication::app_t::applicationFilePath().toUtf8() );
         } else {
             // Running as AppImage: Use absolute path to AppImage file
-            appData.addData( appImagePath.toUtf8() );
+            appData.addData( appImagePath );
         }
 #endif
     }

--- a/singleapplication_p.cpp
+++ b/singleapplication_p.cpp
@@ -147,7 +147,14 @@ void SingleApplicationPrivate::genBlockServerName()
 #ifdef Q_OS_WIN
         appData.addData( SingleApplication::app_t::applicationFilePath().toLower().toUtf8() );
 #else
-        appData.addData( SingleApplication::app_t::applicationFilePath().toUtf8() );
+        QString appImagePath = qEnvironmentVariable( "APPIMAGE" );
+        if ( appImagePath.isEmpty() ) {
+            // Not running as AppImage: use path to executable file
+            appData.addData( SingleApplication::app_t::applicationFilePath().toUtf8() );
+        } else {
+            // Running as AppImage: Use absolute path to AppImage file
+            appData.addData( appImagePath.toUtf8() );
+        }
 #endif
     }
 

--- a/singleapplication_p.cpp
+++ b/singleapplication_p.cpp
@@ -146,7 +146,7 @@ void SingleApplicationPrivate::genBlockServerName()
     if( ! (options & SingleApplication::Mode::ExcludeAppPath) ){
 #if defined(Q_OS_WIN)
         appData.addData( SingleApplication::app_t::applicationFilePath().toLower().toUtf8() );
-#elseif defined(Q_OS_LINUX)
+#elif defined(Q_OS_LINUX)
         // If the application is running as an AppImage then the APPIMAGE env var should be used
         // instead of applicationPath() as each instance is launched with its own executable path
         const QByteArray appImagePath = qgetenv( "APPIMAGE" );

--- a/singleapplication_p.cpp
+++ b/singleapplication_p.cpp
@@ -147,12 +147,12 @@ void SingleApplicationPrivate::genBlockServerName()
 #ifdef Q_OS_WIN
         appData.addData( SingleApplication::app_t::applicationFilePath().toLower().toUtf8() );
 #else
+        // If the application is running as an AppImage then the APPIMAGE env var should be used
+        // instead of applicationPath() as each instance is launched with its own executable path
         const QByteArray appImagePath = qgetenv( "APPIMAGE" );
-        if ( appImagePath.isEmpty() ) {
-            // Not running as AppImage: use path to executable file
+        if( appImagePath.isEmpty() ){ // Not running as AppImage: use path to executable file
             appData.addData( SingleApplication::app_t::applicationFilePath().toUtf8() );
-        } else {
-            // Running as AppImage: Use absolute path to AppImage file
+        } else { // Running as AppImage: Use absolute path to AppImage file
             appData.addData( appImagePath );
         }
 #endif

--- a/singleapplication_p.cpp
+++ b/singleapplication_p.cpp
@@ -146,7 +146,7 @@ void SingleApplicationPrivate::genBlockServerName()
     if( ! (options & SingleApplication::Mode::ExcludeAppPath) ){
 #ifdef Q_OS_WIN
         appData.addData( SingleApplication::app_t::applicationFilePath().toLower().toUtf8() );
-#else
+#elseif defined(Q_OS_LINUX)
         // If the application is running as an AppImage then the APPIMAGE env var should be used
         // instead of applicationPath() as each instance is launched with its own executable path
         const QByteArray appImagePath = qgetenv( "APPIMAGE" );
@@ -154,7 +154,9 @@ void SingleApplicationPrivate::genBlockServerName()
             appData.addData( SingleApplication::app_t::applicationFilePath().toUtf8() );
         } else { // Running as AppImage: Use absolute path to AppImage file
             appData.addData( appImagePath );
-        }
+        };
+#else
+        appData.addData( SingleApplication::app_t::applicationFilePath().toUtf8() );
 #endif
     }
 

--- a/singleapplication_p.cpp
+++ b/singleapplication_p.cpp
@@ -144,7 +144,7 @@ void SingleApplicationPrivate::genBlockServerName()
     }
 
     if( ! (options & SingleApplication::Mode::ExcludeAppPath) ){
-#ifdef Q_OS_WIN
+#if defined(Q_OS_WIN)
         appData.addData( SingleApplication::app_t::applicationFilePath().toLower().toUtf8() );
 #elseif defined(Q_OS_LINUX)
         // If the application is running as an AppImage then the APPIMAGE env var should be used

--- a/singleapplication_p.cpp
+++ b/singleapplication_p.cpp
@@ -147,7 +147,7 @@ void SingleApplicationPrivate::genBlockServerName()
 #ifdef Q_OS_WIN
         appData.addData( SingleApplication::app_t::applicationFilePath().toLower().toUtf8() );
 #else
-        QString appImagePath = qEnvironmentVariable( "APPIMAGE" );
+        const QByteArray appImagePath = qgetenv( "APPIMAGE" );
         if ( appImagePath.isEmpty() ) {
             // Not running as AppImage: use path to executable file
             appData.addData( SingleApplication::app_t::applicationFilePath().toUtf8() );


### PR DESCRIPTION
When an application is launched as AppImage, each instance is launched
from its own FUSE-mounted filesystem, so each instance has its own
executable path.

The AppImage runtime sets the environment variable APPIMAGE to the
absolute path to the .AppImage file, so we can use the content of this
variable instead of QApplication::applicationFilePath() when set.

Closes #77, #137