### PR TITLE
Corrected Git URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ To include the library files I would recommend that you add it as a git
 submodule to your project. Here is how:
 
 ```bash
-git submodule add git@github.com:itay-grudev/SingleApplication.git singleapplication
+git submodule add https://github.com/itay-grudev/SingleApplication.git singleapplication
 ```
 
 **Qmake:**


### PR DESCRIPTION
Should be HTTPS instead of SSH so people with read-only access can use it.