### PR TITLE
fix deprecated warnings on Qt6.3+

### DIFF
--- a/singleapplication_p.cpp
+++ b/singleapplication_p.cpp
@@ -131,7 +131,11 @@ QString SingleApplicationPrivate::getUsername()
 void SingleApplicationPrivate::genBlockServerName()
 {
     QCryptographicHash appData( QCryptographicHash::Sha256 );
+#if QT_VERSION < QT_VERSION_CHECK(6, 3, 0)
     appData.addData( "SingleApplication", 17 );
+#else
+    appData.addData( QByteArrayView{"SingleApplication"} );    
+#endif
     appData.addData( SingleApplication::app_t::applicationName().toUtf8() );
     appData.addData( SingleApplication::app_t::organizationName().toUtf8() );
     appData.addData( SingleApplication::app_t::organizationDomain().toUtf8() );


### PR DESCRIPTION
`void addData(const char *data, qsizetype length);` will be  deprecated from Qt 6.4, so use `QByteArrayView` from Qt 6.3