### PR TITLE
Provide API for blocking sendMessage

### DIFF
--- a/singleapplication.cpp
+++ b/singleapplication.cpp
@@ -238,7 +238,7 @@ QString SingleApplication::currentUser() const
  * @param block block until the primary application exits
  * @return true if the message was sent successfuly, false otherwise.
  */
-bool SingleApplication::sendMessage( const QByteArray &message, int timeout, SendOptions options )
+bool SingleApplication::sendMessage( const QByteArray &message, int timeout, SendMode sendMode )
 {
     Q_D( SingleApplication );
 
@@ -249,7 +249,7 @@ bool SingleApplication::sendMessage( const QByteArray &message, int timeout, Sen
     if( ! d->connectToPrimary( timeout,  SingleApplicationPrivate::Reconnect ) )
       return false;
 
-    return d->writeConfirmedMessage( timeout, message, options );
+    return d->writeConfirmedMessage( timeout, message, sendMode );
 }
 
 /**

--- a/singleapplication.cpp
+++ b/singleapplication.cpp
@@ -235,9 +235,10 @@ QString SingleApplication::currentUser() const
  * Sends message to the Primary Instance.
  * @param message The message to send.
  * @param timeout the maximum timeout in milliseconds for blocking functions.
+ * @param block block until the primary application exits
  * @return true if the message was sent successfuly, false otherwise.
  */
-bool SingleApplication::sendMessage( const QByteArray &message, int timeout )
+bool SingleApplication::sendMessage( const QByteArray &message, int timeout, SendOptions options )
 {
     Q_D( SingleApplication );
 
@@ -248,7 +249,7 @@ bool SingleApplication::sendMessage( const QByteArray &message, int timeout )
     if( ! d->connectToPrimary( timeout,  SingleApplicationPrivate::Reconnect ) )
       return false;
 
-    return d->writeConfirmedMessage( timeout, message );
+    return d->writeConfirmedMessage( timeout, message, options );
 }
 
 /**

--- a/singleapplication.cpp
+++ b/singleapplication.cpp
@@ -235,7 +235,7 @@ QString SingleApplication::currentUser() const
  * Sends message to the Primary Instance.
  * @param message The message to send.
  * @param timeout the maximum timeout in milliseconds for blocking functions.
- * @param block block until the primary application exits
+ * @param sendMode mode of operation
  * @return true if the message was sent successfuly, false otherwise.
  */
 bool SingleApplication::sendMessage( const QByteArray &message, int timeout, SendMode sendMode )

--- a/singleapplication.h
+++ b/singleapplication.h
@@ -129,19 +129,19 @@ public:
      * @enum
      */
     enum SendMode {
-        NonBlocking,  /** Do not wait for the primary instance termination and return immediately */
-        Blocking,  /** Wait until the primary instance is terminated */
+        NonBlocking,            /** Do not wait for the primary instance termination and return immediately */
+        BlockUntilPrimaryExit,  /** Wait until the primary instance is terminated */
     };
 
     /**
      * @brief Sends a message to the primary instance. Returns true on success.
      * @param {int} timeout - Timeout for connecting
-     * @param {bool} block - Block until the primary application exits.
+     * @param {SendMode} sendMode - Mode of operation.
      * @returns {bool}
      * @note sendMessage() will return false if invoked from the primary
      * instance.
      */
-    bool sendMessage( const QByteArray &message, int timeout = 100, SendOptions options = {} );
+    bool sendMessage( const QByteArray &message, int timeout = 100, SendMode sendMode = NonBlocking );
 
     /**
      * @brief Get the set user data.

--- a/singleapplication.h
+++ b/singleapplication.h
@@ -129,12 +129,9 @@ public:
      * @enum
      */
     enum SendMode {
-        /**
-         * Should the sendMessage call block until the primary instance is terminated?
-         */
-        BlockingSend = 1 << 0,
+        NonBlocking,  /** Do not wait for the primary instance termination and return immediately */
+        Blocking,  /** Wait until the primary instance is terminated */
     };
-    Q_DECLARE_FLAGS(SendOptions, SendMode)
 
     /**
      * @brief Sends a message to the primary instance. Returns true on success.

--- a/singleapplication.h
+++ b/singleapplication.h
@@ -125,13 +125,26 @@ public:
     QString currentUser() const;
 
     /**
+     * @brief Mode of operation of sendMessage.
+     * @enum
+     */
+    enum SendMode {
+        /**
+         * Should the sendMessage call block until the primary instance is terminated?
+         */
+        BlockingSend = 1 << 0,
+    };
+    Q_DECLARE_FLAGS(SendOptions, SendMode)
+
+    /**
      * @brief Sends a message to the primary instance. Returns true on success.
      * @param {int} timeout - Timeout for connecting
+     * @param {bool} block - Block until the primary application exits.
      * @returns {bool}
      * @note sendMessage() will return false if invoked from the primary
      * instance.
      */
-    bool sendMessage( const QByteArray &message, int timeout = 100 );
+    bool sendMessage( const QByteArray &message, int timeout = 100, SendOptions options = {} );
 
     /**
      * @brief Get the set user data.

--- a/singleapplication.h
+++ b/singleapplication.h
@@ -129,7 +129,7 @@ public:
      * @enum
      */
     enum SendMode {
-        NonBlocking,            /** Do not wait for the primary instance termination and return immediately */
+        NonBlocking,  /** Do not wait for the primary instance termination and return immediately */
         BlockUntilPrimaryExit,  /** Wait until the primary instance is terminated */
     };
 

--- a/singleapplication_p.cpp
+++ b/singleapplication_p.cpp
@@ -283,7 +283,7 @@ void SingleApplicationPrivate::writeAck( QLocalSocket *sock ) {
     sock->putChar('\n');
 }
 
-bool SingleApplicationPrivate::writeConfirmedMessage (int msecs, const QByteArray &msg, SingleApplication::SendOptions options)
+bool SingleApplicationPrivate::writeConfirmedMessage (int msecs, const QByteArray &msg, SingleApplication::SendMode sendMode)
 {
     QElapsedTimer time;
     time.start();
@@ -304,7 +304,7 @@ bool SingleApplicationPrivate::writeConfirmedMessage (int msecs, const QByteArra
     const bool result = writeConfirmedFrame( static_cast<int>(msecs - time.elapsed()), msg );
 
     // Block if needed
-    if (socket && (options & SingleApplication::BlockingSend))
+    if (socket && (sendMode == SingleApplication::BlockUntilPrimaryExit))
         socket->waitForDisconnected(-1);
 
     return result;

--- a/singleapplication_p.cpp
+++ b/singleapplication_p.cpp
@@ -303,7 +303,7 @@ bool SingleApplicationPrivate::writeConfirmedMessage (int msecs, const QByteArra
     // Frame 2: The message
     const bool result = writeConfirmedFrame( static_cast<int>(msecs - time.elapsed()), msg );
 
-    // block if needed
+    // Block if needed
     if (socket && (options & SingleApplication::BlockingSend))
         socket->waitForDisconnected(-1);
 

--- a/singleapplication_p.cpp
+++ b/singleapplication_p.cpp
@@ -304,7 +304,7 @@ bool SingleApplicationPrivate::writeConfirmedMessage (int msecs, const QByteArra
     const bool result = writeConfirmedFrame( static_cast<int>(msecs - time.elapsed()), msg );
 
     // Block if needed
-    if (socket && (sendMode == SingleApplication::BlockUntilPrimaryExit))
+    if (socket && sendMode == SingleApplication::BlockUntilPrimaryExit)
         socket->waitForDisconnected(-1);
 
     return result;

--- a/singleapplication_p.cpp
+++ b/singleapplication_p.cpp
@@ -283,7 +283,7 @@ void SingleApplicationPrivate::writeAck( QLocalSocket *sock ) {
     sock->putChar('\n');
 }
 
-bool SingleApplicationPrivate::writeConfirmedMessage (int msecs, const QByteArray &msg)
+bool SingleApplicationPrivate::writeConfirmedMessage (int msecs, const QByteArray &msg, SingleApplication::SendOptions options)
 {
     QElapsedTimer time;
     time.start();
@@ -301,7 +301,13 @@ bool SingleApplicationPrivate::writeConfirmedMessage (int msecs, const QByteArra
         return false;
 
     // Frame 2: The message
-    return writeConfirmedFrame( static_cast<int>(msecs - time.elapsed()), msg );
+    const bool result = writeConfirmedFrame( static_cast<int>(msecs - time.elapsed()), msg );
+
+    // block if needed
+    if (socket && (options & SingleApplication::BlockingSend))
+        socket->waitForDisconnected(-1);
+
+    return result;
 }
 
 bool SingleApplicationPrivate::writeConfirmedFrame( int msecs, const QByteArray &msg )

--- a/singleapplication_p.h
+++ b/singleapplication_p.h
@@ -85,7 +85,7 @@ public:
     void readInitMessageBody(QLocalSocket *socket);
     void writeAck(QLocalSocket *sock);
     bool writeConfirmedFrame(int msecs, const QByteArray &msg);
-    bool writeConfirmedMessage(int msecs, const QByteArray &msg, SingleApplication::SendOptions options = {});
+    bool writeConfirmedMessage(int msecs, const QByteArray &msg, SingleApplication::SendMode sendMode = SingleApplication::NonBlocking);
     static void randomSleep();
     void addAppData(const QString &data);
     QStringList appData() const;

--- a/singleapplication_p.h
+++ b/singleapplication_p.h
@@ -85,7 +85,7 @@ public:
     void readInitMessageBody(QLocalSocket *socket);
     void writeAck(QLocalSocket *sock);
     bool writeConfirmedFrame(int msecs, const QByteArray &msg);
-    bool writeConfirmedMessage(int msecs, const QByteArray &msg);
+    bool writeConfirmedMessage(int msecs, const QByteArray &msg, SingleApplication::SendOptions options = {});
     static void randomSleep();
     void addAppData(const QString &data);
     QStringList appData() const;


### PR DESCRIPTION
useful if the secondary instances should wait until the primary exits

use e.g. in Kate for the kate -b xyz blocking behavior

As promised in the other pull request, here my additional api for blocking send, cleaned up a bit with an extra enum.