### PR TITLE
Doxygen Awesome Fork URL Fix

### DIFF
--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -23,12 +23,12 @@ jobs:
         run: |
           cmake -B build -D DOXYGEN_WARN_AS_ERROR=YES
           cmake --build build --target SingleApplicationDocumentation
+          find build/html/ -name *.html -type f -exec sed -i 's+https://github.com/jothepro/doxygen-awesome-css+https://github.com/itay-grudev/SingleApplication+g' {} \;
 
       - name: Deploy to GitHub pages
         on:
           branches:
             - master
-
         uses: crazy-max/ghaction-github-pages@v3
         with:
           target_branch: gh-pages

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,11 +76,4 @@ if(DOXYGEN_FOUND)
         Windows.md
         README.md
     )
-
-    add_custom_command(
-        TARGET ${PROJECT_NAME}Documentation POST_BUILD
-        COMMAND find html/ -name *.html -type f -exec sed -i 's+https://github.com/jothepro/doxygen-awesome-css+https://github.com/itay-grudev/SingleApplication+g' {} \\\;
-        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-        COMMENT "Replacing project URL"
-    )
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,4 +76,11 @@ if(DOXYGEN_FOUND)
         Windows.md
         README.md
     )
+
+    add_custom_command(
+        TARGET ${PROJECT_NAME}Documentation POST_BUILD
+        COMMAND find html/ -name *.html -type f -exec sed -i 's+https://github.com/jothepro/doxygen-awesome-css+https://github.com/itay-grudev/SingleApplication+g' {} \\\;
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        COMMENT "Replacing project URL"
+    )
 endif()


### PR DESCRIPTION
Fixes the Fork URL in the `documentation pointing to Doxygen Awesome instead of our GitHub.