### PR TITLE
Windows raise widget example

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,7 +59,7 @@ jobs:
           cmake . ${{ matrix.additional_arguments }}
           cmake --build .
 
-      - name: Build calculator example CMake
+      - name: Build calculator example with CMake
         working-directory: examples/calculator/
         run: |
           cmake . ${{ matrix.additional_arguments }}
@@ -67,6 +67,12 @@ jobs:
 
       - name: Build sending_arguments example with CMake
         working-directory: examples/sending_arguments/
+        run: |
+          cmake . ${{ matrix.additional_arguments }}
+          cmake --build .
+
+      - name: Build windows_raise_widget example with CMake
+        working-directory: examples/windows_raise_widget/
         run: |
           cmake . ${{ matrix.additional_arguments }}
           cmake --build .
@@ -80,7 +86,7 @@ jobs:
           qmake
           ${{ matrix.make }}
 
-      - name: Build calculator example QMake
+      - name: Build calculator example with QMake
         working-directory: examples/calculator/
         run: |
           qmake
@@ -88,6 +94,12 @@ jobs:
 
       - name: Build sending_arguments example with QMake
         working-directory: examples/sending_arguments/
+        run: |
+          qmake
+          ${{ matrix.make }}
+
+      - name: Build windows_raise_widget example with QMake
+        working-directory: examples/windows_raise_widget/
         run: |
           qmake
           ${{ matrix.make }}

--- a/Windows.md
+++ b/Windows.md
@@ -13,30 +13,41 @@ details.
 The background process (the primary instance) can bring its windows to the
 foreground if it is allowed by the current foreground process (the secondary
 instance). To bypass this `SingleApplication` must be initialized with the
-`allowSecondary` parameter set to `true` and the `options` parameter must
-include `Mode::SecondaryNotification`, See `SingleApplication::Mode` for more
-details.
+`allowSecondary` parameter set to `true` .
 
-Here is an example:
+If the widget is minimized to Windows task bar, `QWidget::raise()` or
+`QWidget::show()` can not bring it to the front, you have to use Windows API
+`ShowWindow()` .
+
+Here is an example, you can find this project in the example directory:
 
 ```cpp
-if( app.isSecondary() ) {
+SingleApplication app(argc, argv, true);
+if ( app.isSecondary() ) {
     // This API requires LIBS += User32.lib to be added to the project
     AllowSetForegroundWindow( DWORD( app.primaryPid() ) );
+
+    objApp.sendMessage("SHOW_WINDOW");
+
+    return 0;
 }
 
-if( app.isPrimary() ) {
-    QObject::connect(
-        &app,
-        &SingleApplication::instanceStarted,
-        this,
-        &App::instanceStarted
-    );
-}
+QWidget* widget = new QWidget;
+
+QObject::connect(&app, &SingleApplication::receivedMessage,
+                 widget, [widget] () { RaiseWidget(widget); } );
 ```
 
 ```cpp
-void App::instanceStarted() {
-    QApplication::setActiveWindow( [window/widget to set to the foreground] );
+void RaiseWidget(QWidget* widget) {
+
+    HWND hwnd = (HWND)widget->winId();
+
+    // check if widget is minimized
+    if (::IsIconic(hwnd)) {
+        ::ShowWindow(hwnd, SW_RESTORE);
+    }
+
+    ::SetForegroundWindow(hwnd);
 }
 ```

--- a/Windows.md
+++ b/Windows.md
@@ -18,4 +18,4 @@ If the widget is minimized to Windows task bar, `QWidget::raise()` or
 `QWidget::show()` can not bring it to the front, you have to use Windows API
 `ShowWindow()` .
 
-You can find demo code in the [examples](examples/windows_raise_widget/main.cpp) directory.
+You can find [demo code](examples/windows_raise_widget/main.cpp) in the examples directory.

--- a/Windows.md
+++ b/Windows.md
@@ -7,8 +7,7 @@ application can bring it's primary instance window whenever a second copy
 of the application is started.
 
 On Windows the ability to bring the application windows to the foreground is
-restricted, see [AllowSetForegroundWindow()][https://msdn.microsoft.com/en-us/library/windows/desktop/ms632668.aspx] for more
-details.
+restricted, see [AllowSetForegroundWindow()](https://msdn.microsoft.com/en-us/library/windows/desktop/ms632668.aspx) for more details.
 
 The background process (the primary instance) can bring its windows to the
 foreground if it is allowed by the current foreground process (the secondary
@@ -19,35 +18,4 @@ If the widget is minimized to Windows task bar, `QWidget::raise()` or
 `QWidget::show()` can not bring it to the front, you have to use Windows API
 `ShowWindow()` .
 
-Here is an example, you can find this project in the example directory:
-
-```cpp
-SingleApplication app(argc, argv, true);
-if ( app.isSecondary() ) {
-    // This API requires LIBS += User32.lib to be added to the project
-    AllowSetForegroundWindow( DWORD( app.primaryPid() ) );
-
-    objApp.sendMessage("SHOW_WINDOW");
-
-    return 0;
-}
-
-QWidget* widget = new QWidget;
-
-QObject::connect(&app, &SingleApplication::receivedMessage,
-                 widget, [widget] () { RaiseWidget(widget); } );
-```
-
-```cpp
-void RaiseWidget(QWidget* widget) {
-
-    HWND hwnd = (HWND)widget->winId();
-
-    // check if widget is minimized
-    if (::IsIconic(hwnd)) {
-        ::ShowWindow(hwnd, SW_RESTORE);
-    }
-
-    ::SetForegroundWindow(hwnd);
-}
-```
+You can find demo code in the [examples](examples/windows_raise_widget/main.cpp) directory.

--- a/examples/windows_raise_widget/CMakeLists.txt
+++ b/examples/windows_raise_widget/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.7.0)
+
+project(windows_raise_widget LANGUAGES CXX)
+
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_WIN32_EXECUTABLE TRUE)
+
+if (NOT DEFINED ENV{CMAKE_PREFIX_PATH})
+  set (ENV{CMAKE_PREFIX_PATH} "C:/Qt/Qt5.12.10/5.12.10/msvc2017_64")
+endif ()
+
+# SingleApplication base class
+set(QAPPLICATION_CLASS QApplication)
+add_subdirectory(../.. SingleApplication)
+
+find_package(Qt${QT_DEFAULT_MAJOR_VERSION} COMPONENTS Core Widgets REQUIRED)
+
+add_executable(${PROJECT_NAME} main.cpp)
+
+target_link_libraries(${PROJECT_NAME} SingleApplication::SingleApplication user32.lib)

--- a/examples/windows_raise_widget/CMakeLists.txt
+++ b/examples/windows_raise_widget/CMakeLists.txt
@@ -5,10 +5,6 @@ project(windows_raise_widget LANGUAGES CXX)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_WIN32_EXECUTABLE TRUE)
 
-if (NOT DEFINED ENV{CMAKE_PREFIX_PATH})
-  set (ENV{CMAKE_PREFIX_PATH} "C:/Qt/Qt5.12.10/5.12.10/msvc2017_64")
-endif ()
-
 # SingleApplication base class
 set(QAPPLICATION_CLASS QApplication)
 add_subdirectory(../.. SingleApplication)
@@ -17,4 +13,4 @@ find_package(Qt${QT_DEFAULT_MAJOR_VERSION} COMPONENTS Core Widgets REQUIRED)
 
 add_executable(${PROJECT_NAME} main.cpp)
 
-target_link_libraries(${PROJECT_NAME} SingleApplication::SingleApplication user32.lib)
+target_link_libraries(${PROJECT_NAME} SingleApplication::SingleApplication)

--- a/examples/windows_raise_widget/main.cpp
+++ b/examples/windows_raise_widget/main.cpp
@@ -1,41 +1,59 @@
 
-#include <Windows.h>
-
 #include <QWidget>
 
 #include "singleapplication.h"
 
-void RaiseWidget(QWidget* pWidget);
+#ifdef Q_OS_WINDOWS
+#include <Windows.h>
+#endif
+
+void raiseWidget(QWidget* widget);
 
 int main(int argc, char *argv[]) {
 
+#ifdef Q_OS_WINDOWS
     SingleApplication app(argc, argv, true);
 
     if (app.isSecondary()) {
 
         AllowSetForegroundWindow( DWORD( app.primaryPid() ) );
 
-        app.sendMessage("SHOW_WINDOW");
+        app.sendMessage("RAISE_WIDGET");
 
         return 0;
     }
+#else
+    SingleApplication app(argc, argv);
+#endif
 
     QWidget* widget = new QWidget;
 
+#ifdef Q_OS_WINDOWS
     QObject::connect(&app, &SingleApplication::receivedMessage,
-                     widget, [widget] () { RaiseWidget(widget); } );
+                     widget, [widget] () { raiseWidget(widget); } );
+#else
+    QObject::connect(&app, &SingleApplication::instanceStarted,
+                     widget, [widget] () { raiseWidget(widget); } );
+#endif
+
     widget->show();
 
     return app.exec();
 }
 
-void RaiseWidget(QWidget* widget) {
-
+void raiseWidget(QWidget* widget) {
+#ifdef Q_OS_WINDOWS
     HWND hwnd = (HWND)widget->winId();
 
+    // check if widget is minimized to Windows task bar
     if (::IsIconic(hwnd)) {
         ::ShowWindow(hwnd, SW_RESTORE);
     }
 
     ::SetForegroundWindow(hwnd);
+#else
+    widget->show();
+    widget->raise();
+    widget->activateWindow();
+#endif
 }

--- a/examples/windows_raise_widget/main.cpp
+++ b/examples/windows_raise_widget/main.cpp
@@ -1,0 +1,41 @@
+
+#include <Windows.h>
+
+#include <QWidget>
+
+#include "singleapplication.h"
+
+void RaiseWidget(QWidget* pWidget);
+
+int main(int argc, char *argv[]) {
+
+    SingleApplication app(argc, argv, true);
+
+    if (app.isSecondary()) {
+
+        AllowSetForegroundWindow( DWORD( app.primaryPid() ) );
+
+        app.sendMessage("SHOW_WINDOW");
+
+        return 0;
+    }
+
+    QWidget* widget = new QWidget;
+
+    QObject::connect(&app, &SingleApplication::receivedMessage,
+                     widget, [widget] () { RaiseWidget(widget); } );
+    widget->show();
+
+    return app.exec();
+}
+
+void RaiseWidget(QWidget* widget) {
+
+    HWND hwnd = (HWND)widget->winId();
+
+    if (::IsIconic(hwnd)) {
+        ::ShowWindow(hwnd, SW_RESTORE);
+    }
+
+    ::SetForegroundWindow(hwnd);
+}

--- a/examples/windows_raise_widget/windows_raise_widget.pro
+++ b/examples/windows_raise_widget/windows_raise_widget.pro
@@ -1,0 +1,7 @@
+# Single Application implementation
+include(../../singleapplication.pri)
+DEFINES += QAPPLICATION_CLASS=QApplication
+
+QT += widgets
+SOURCES += main.cpp
+LIBS += User32.lib

--- a/examples/windows_raise_widget/windows_raise_widget.pro
+++ b/examples/windows_raise_widget/windows_raise_widget.pro
@@ -4,4 +4,7 @@ DEFINES += QAPPLICATION_CLASS=QApplication
 
 QT += widgets
 SOURCES += main.cpp
-LIBS += User32.lib
+
+win32{
+  LIBS += User32.lib
+}


### PR DESCRIPTION
Bring widget to the front when second instance is started, this is a workaround for Windows system.