### PR TITLE
SingleApplication: Fix double free on exit

### DIFF
--- a/singleapplication.cpp
+++ b/singleapplication.cpp
@@ -262,7 +262,6 @@ void SingleApplication::abortSafely()
     Q_D( SingleApplication );
 
     qCritical() << "SingleApplication: " << d->memory->error() << d->memory->errorString();
-    delete d;
     ::exit( EXIT_FAILURE );
 }
 


### PR DESCRIPTION
The private data is free'd in the destructor.