### PR TITLE
Improve Windows link library dependency

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,6 +54,9 @@ jobs:
         with:
           version: ${{ matrix.qt_version }}
 
+      - name: Setup MSVC environment for QMake
+        uses: ilammy/msvc-dev-cmd@v1
+
       - name: Build library with CMake
         run: |
           cmake . ${{ matrix.additional_arguments }}
@@ -82,9 +85,6 @@ jobs:
         run: |
           cmake . ${{ matrix.additional_arguments }}
           cmake --build .
-
-      - name: Setup MSVC environment for QMake
-        uses: ilammy/msvc-dev-cmd@v1
 
       - name: Build basic example with QMake
         working-directory: examples/basic/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.4.1
+
+* Improved Windows link library dependency. - _Frederik Seiffert_
+
 ## 3.4.0
 
 * Provide API for blocking sendMessage. - _Christoph Cullmann_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.4.1
 
-* Improved Windows link library dependency. - _Frederik Seiffert_
+* Improved Windows advapi32 link library dependency. - _Frederik Seiffert_
 
 ## 3.4.0
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,9 @@ endif()
 target_link_libraries(${PROJECT_NAME} PUBLIC ${QT_LIBRARIES})
 
 if(WIN32)
-    target_link_libraries(${PROJECT_NAME} PRIVATE advapi32)
+    find_library(advapi32_LIBRARY advapi32 REQUIRED)
+    mark_as_advanced(advapi32_LIBRARY)
+    target_link_libraries(${PROJECT_NAME} PRIVATE ${advapi32_LIBRARY})
 endif()
 
 target_compile_definitions(${PROJECT_NAME} PUBLIC QAPPLICATION_CLASS=${QAPPLICATION_CLASS})


### PR DESCRIPTION
Fixes an error when building with [`CMAKE_LINK_LIBRARIES_ONLY_TARGETS`](https://cmake.org/cmake/help/latest/prop_tgt/LINK_LIBRARIES_ONLY_TARGETS.html) enabled.