### PR TITLE
Use new QNativeIpcKey based QSharedMemory constructor with Qt 6.6 and higher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.5.0
+
+* Switch to the new QNativeIpcKey based QSharedMemory constructor with Qt 6.6 and higher. - _Jonas Kvinge_
+
 ## 3.4.1
 
 * Improved Windows advapi32 link library dependency. - _Frederik Seiffert_

--- a/singleapplication.cpp
+++ b/singleapplication.cpp
@@ -67,12 +67,20 @@ SingleApplication::SingleApplication( int &argc, char *argv[], bool allowSeconda
 #ifdef Q_OS_UNIX
     // By explicitly attaching it and then deleting it we make sure that the
     // memory is deleted even after the process has crashed on Unix.
+#if QT_VERSION >= QT_VERSION_CHECK(6, 6, 0)
+    d->memory = new QSharedMemory( QNativeIpcKey( d->blockServerName ) );
+#else
     d->memory = new QSharedMemory( d->blockServerName );
+#endif
     d->memory->attach();
     delete d->memory;
 #endif
     // Guarantee thread safe behaviour with a shared memory block.
+#if QT_VERSION >= QT_VERSION_CHECK(6, 6, 0)
+    d->memory = new QSharedMemory( QNativeIpcKey( d->blockServerName ) );
+#else
     d->memory = new QSharedMemory( d->blockServerName );
+#endif
 
     // Create a shared memory block
     if( d->memory->create( sizeof( InstancesInfo ) )){


### PR DESCRIPTION
Switch to the new QNativeIpcKey based QSharedMemory constructor with Qt 6.6 and higher, the old constructor will be deprecated. This also makes the library work again with the upcoming Qt 6.6 release and higher. However, there are still issues with releasing the existing memory in cases where the application is forcefully quit or crashed.
