### PR TITLE
SingleApplicationPrivate: Use MD5 on macOS for block server name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.5.1
+
+* Bug Fix: Maximum QNativeIpcKey key size on macOS. - _Jonas Kvinge_
+
 ## 3.5.0
 
 * Switch to the new QNativeIpcKey based QSharedMemory constructor with Qt 6.6 and higher. - _Jonas Kvinge_

--- a/singleapplication_p.cpp
+++ b/singleapplication_p.cpp
@@ -131,7 +131,12 @@ QString SingleApplicationPrivate::getUsername()
 
 void SingleApplicationPrivate::genBlockServerName()
 {
+#ifdef Q_OS_MACOS
+    // Maximum key size on macOS is PSHMNAMLEN (31).
+    QCryptographicHash appData( QCryptographicHash::Md5 );
+#else
     QCryptographicHash appData( QCryptographicHash::Sha256 );
+#endif
 #if QT_VERSION < QT_VERSION_CHECK(6, 3, 0)
     appData.addData( "SingleApplication", 17 );
 #else


### PR DESCRIPTION
Maximum key size on macOS is PSHMNAMLEN (31).

Fixes #178