### PR TITLE
fix Could not find advapi32_LIBRARY 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,9 +38,7 @@ endif()
 target_link_libraries(${PROJECT_NAME} PUBLIC ${QT_LIBRARIES})
 
 if(WIN32)
-    find_library(advapi32_LIBRARY advapi32 REQUIRED)
-    mark_as_advanced(advapi32_LIBRARY)
-    target_link_libraries(${PROJECT_NAME} PRIVATE ${advapi32_LIBRARY})
+    target_link_libraries(${PROJECT_NAME} PRIVATE advapi32)
 endif()
 
 target_compile_definitions(${PROJECT_NAME} PUBLIC QAPPLICATION_CLASS=${QAPPLICATION_CLASS})


### PR DESCRIPTION
A fix for the #183 issue on Windows