### PR TITLE
Check the primary connection and assume primary if no response is found.

### DIFF
--- a/singleapplication.cpp
+++ b/singleapplication.cpp
@@ -137,6 +137,13 @@ SingleApplication::SingleApplication( int &argc, char *argv[], bool allowSeconda
       }
     }
 
+    // Check to ensure the primary process really does exist by sending a message and if it does not
+    // then assume primary status
+    if ( inst->primary != false && !d->connectToPrimary( timeout, SingleApplicationPrivate::SecondaryInstance )) {
+          qDebug() << "SingleApplication: Cannot communicate with primary so assuming primary status.";
+          inst->primary = false;
+    }
+
     if( inst->primary == false ){
         d->startPrimary();
         if( ! d->memory->unlock() ){


### PR DESCRIPTION
This guards against the case of stale shared memory that can happen when the primary application crashes or is forcefully killed.

Issue #190