### PR TITLE
Enable app class independent usage

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,6 +80,12 @@ jobs:
           cmake . ${{ matrix.additional_arguments }}
           cmake --build .
 
+      - name: Build separate_object example with CMake
+        working-directory: examples/separate_object/
+        run: |
+          cmake . ${{ matrix.additional_arguments }}
+          cmake --build .
+
       - name: Build windows_raise_widget example with CMake
         working-directory: examples/windows_raise_widget/
         run: |
@@ -103,6 +109,13 @@ jobs:
       - name: Build sending_arguments example with QMake
         if: ${{ !contains(matrix.platform, 'macos') }}
         working-directory: examples/sending_arguments/
+        run: |
+          qmake
+          ${{ matrix.make }}
+
+      - name: Build separate_object example with QMake
+        if: ${{ !contains(matrix.platform, 'macos') }}
+        working-directory: examples/separate_object/
         run: |
           qmake
           ${{ matrix.make }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,24 +87,28 @@ jobs:
           cmake --build .
 
       - name: Build basic example with QMake
+        if: ${{ !contains(matrix.platform, 'macos') }}
         working-directory: examples/basic/
         run: |
           qmake
           ${{ matrix.make }}
 
       - name: Build calculator example with QMake
+        if: ${{ !contains(matrix.platform, 'macos') }}
         working-directory: examples/calculator/
         run: |
           qmake
           ${{ matrix.make }}
 
       - name: Build sending_arguments example with QMake
+        if: ${{ !contains(matrix.platform, 'macos') }}
         working-directory: examples/sending_arguments/
         run: |
           qmake
           ${{ matrix.make }}
 
       - name: Build windows_raise_widget example with QMake
+        if: ${{ !contains(matrix.platform, 'macos') }}
         working-directory: examples/windows_raise_widget/
         run: |
           qmake

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
         platform:
           - ubuntu-20.04
           - windows-latest
-          - macos-latest
+          - macos-13
         include:
           - qt_version: 6.2.4
             additional_arguments: -D QT_DEFAULT_MAJOR_VERSION=6
@@ -32,7 +32,7 @@ jobs:
             make: make
             CXXFLAGS: -Wall -Wextra -pedantic -Werror
             MAKEFLAGS: -j2
-          - platform: macos-latest
+          - platform: macos-13
             make: make
             CXXFLAGS: -Wall -Wextra -pedantic -Werror
             MAKEFLAGS: -j3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 3.6.0
+
+* Freestanding mode where `SingleApplication` doesn't derive from `QCodeApplication` _Benjamin Buch_
+* CMake install with CMake config files for freestanding mode _Benjamin Buch_
+
 ## 3.5.1
 
 * Bug Fix: Maximum QNativeIpcKey key size on macOS. - _Jonas Kvinge_

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,8 +10,13 @@ add_library(${PROJECT_NAME} STATIC
 )
 add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
+# User configurable options
 if(NOT QT_DEFAULT_MAJOR_VERSION)
     set(QT_DEFAULT_MAJOR_VERSION 5 CACHE STRING "Qt version to use (5 or 6), defaults to 5")
+endif()
+
+if(NOT QAPPLICATION_CLASS)
+    set(QAPPLICATION_CLASS QCoreApplication CACHE STRING "Qt application base class or FreeStandingSingleApplication")
 endif()
 
 # Find dependencies
@@ -24,8 +29,6 @@ if(QAPPLICATION_CLASS STREQUAL QApplication)
 elseif(QAPPLICATION_CLASS STREQUAL QGuiApplication)
     list(APPEND QT_COMPONENTS Gui)
     list(APPEND QT_LIBRARIES Qt${QT_DEFAULT_MAJOR_VERSION}::Gui)
-else()
-    set(QAPPLICATION_CLASS QCoreApplication)
 endif()
 
 find_package(Qt${QT_DEFAULT_MAJOR_VERSION} COMPONENTS ${QT_COMPONENTS} REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.12.0)
 
-project(SingleApplication LANGUAGES CXX DESCRIPTION "Replacement for QtSingleApplication")
+project(SingleApplication VERSION 3.6.0 LANGUAGES CXX DESCRIPTION "Replacement for QtSingleApplication")
 
 set(CMAKE_AUTOMOC ON)
 
@@ -8,7 +8,6 @@ add_library(${PROJECT_NAME} STATIC
     singleapplication.cpp
     singleapplication_p.cpp
 )
-add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
 # User configurable options
 if(NOT QT_DEFAULT_MAJOR_VERSION)
@@ -17,6 +16,12 @@ endif()
 
 if(NOT QAPPLICATION_CLASS)
     set(QAPPLICATION_CLASS QCoreApplication CACHE STRING "Qt application base class or FreeStandingSingleApplication")
+endif()
+
+option(SINGLEAPPLICATION_INSTALL OFF "Enable freestanding mode install including config files")
+
+if(SINGLEAPPLICATION_INSTALL AND NOT QAPPLICATION_CLASS STREQUAL "FreeStandingSingleApplication")
+    message(FATAL_ERROR "SINGLEAPPLICATION_INSTALL requires QAPPLICATION_CLASS == FreeStandingSingleApplication")
 endif()
 
 # Find dependencies
@@ -44,8 +49,15 @@ if(WIN32)
     target_link_libraries(${PROJECT_NAME} PRIVATE advapi32)
 endif()
 
-target_compile_definitions(${PROJECT_NAME} PUBLIC QAPPLICATION_CLASS=${QAPPLICATION_CLASS})
-target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+if(SINGLEAPPLICATION_INSTALL)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE QAPPLICATION_CLASS=${QAPPLICATION_CLASS})
+    target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+    target_include_directories(${PROJECT_NAME} INTERFACE $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+else()
+    target_compile_definitions(${PROJECT_NAME} PUBLIC QAPPLICATION_CLASS=${QAPPLICATION_CLASS})
+    target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+endif()
+
 target_compile_definitions(${PROJECT_NAME} PRIVATE
     QT_NO_CAST_TO_ASCII
     QT_NO_CAST_FROM_ASCII
@@ -83,4 +95,53 @@ if(DOXYGEN_FOUND)
         Windows.md
         README.md
     )
+endif()
+
+if(SINGLEAPPLICATION_INSTALL)
+    # Create a header veriant where QAPPLICATION_CLASS is replaced with FreeStandingSingleApplication
+    file(READ "${CMAKE_CURRENT_SOURCE_DIR}/singleapplication.h" SINGLEAPPLICATION_H_CONTENT)
+
+    string(REGEX REPLACE
+        "#ifndef QAPPLICATION_CLASS[^\n]*\n[ \t]*#define QAPPLICATION_CLASS QCoreApplication[^\n]*\n[ \t]*#endif[^\n]*\n"
+        ""
+        SINGLEAPPLICATION_H_CONTENT
+        "${SINGLEAPPLICATION_H_CONTENT}")
+
+    string(REGEX REPLACE
+        "#include QT_STRINGIFY\\(QAPPLICATION_CLASS\\)"
+        "#include \"FreeStandingSingleApplication\""
+        SINGLEAPPLICATION_H_CONTENT
+        "${SINGLEAPPLICATION_H_CONTENT}")
+
+    string(REPLACE
+        "QAPPLICATION_CLASS"
+        "FreeStandingSingleApplication"
+        SINGLEAPPLICATION_H_CONTENT
+        "${SINGLEAPPLICATION_H_CONTENT}")
+
+    file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/singleapplication.h" "${SINGLEAPPLICATION_H_CONTENT}")
+
+    # CMake install
+    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/singleapplication.h" "SingleApplication" "FreeStandingSingleApplication"
+        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+
+    include(CMakePackageConfigHelpers)
+    write_basic_package_version_file(
+        "SingleApplicationConfigVersion.cmake"
+        VERSION "${PACKAGE_VERSION}"
+        COMPATIBILITY SameMajorVersion)
+
+    configure_file("SingleApplicationConfig.cmake.in" "SingleApplicationConfig.cmake" @ONLY)
+    install(FILES
+        "${CMAKE_CURRENT_BINARY_DIR}/SingleApplicationConfig.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/SingleApplicationConfigVersion.cmake"
+        DESTINATION "lib/cmake/SingleApplication")
+
+    install(TARGETS SingleApplication EXPORT SingleApplicationTargets)
+    install(EXPORT SingleApplicationTargets
+        FILE "SingleApplicationTargets.cmake"
+        NAMESPACE "SingleApplication::"
+        DESTINATION "lib/cmake/SingleApplication")
+else()
+    add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 endif()

--- a/FreeStandingSingleApplication
+++ b/FreeStandingSingleApplication
@@ -1,0 +1,41 @@
+// Copyright (c) Itay Grudev 2015 - 2023
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// Permission is not granted to use this software or any of the associated files
+// as sample data for the purposes of building machine learning models.
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#ifndef FREE_STANDING_SINGLE_APPLICATION_H
+#define FREE_STANDING_SINGLE_APPLICATION_H
+
+#include <QCoreApplication>
+
+/**
+ * @brief Fake Qt application base class
+ * Use this as base if you want to use SingleApplication as a free standing object that must be
+ * explicitly instanciated after your Qt application object.
+ *
+ * This enables you to use SingleApplication as a precompiled library and/or to decide at runtime
+ * if you want to use a SingleApplication instance or not.
+ */
+struct FreeStandingSingleApplication: QObject{
+  FreeStandingSingleApplication( int&, char** ) {}
+};
+
+#endif

--- a/SingleApplicationConfig.cmake.in
+++ b/SingleApplicationConfig.cmake.in
@@ -1,0 +1,5 @@
+include(CMakeFindDependencyMacro)
+
+find_dependency(Qt@QT_DEFAULT_MAJOR_VERSION@ COMPONENTS Core Network REQUIRED)
+
+include("${CMAKE_CURRENT_LIST_DIR}/SingleApplicationTargets.cmake")

--- a/examples/separate_object/CMakeLists.txt
+++ b/examples/separate_object/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.7.0)
+
+project(separate_object LANGUAGES CXX)
+
+set(CMAKE_AUTOMOC ON)
+
+# SingleApplication base class
+set(QAPPLICATION_CLASS FreeStandingSingleApplication)
+add_subdirectory(../.. SingleApplication)
+
+find_package(Qt${QT_DEFAULT_MAJOR_VERSION} COMPONENTS Core REQUIRED)
+
+add_executable(${PROJECT_NAME}
+    main.cpp
+    messagereceiver.cpp
+    messagereceiver.h
+    main.cpp
+)
+
+target_link_libraries(${PROJECT_NAME} SingleApplication::SingleApplication)

--- a/examples/separate_object/main.cpp
+++ b/examples/separate_object/main.cpp
@@ -1,0 +1,53 @@
+// Copyright (c) Itay Grudev 2015 - 2023
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// Permission is not granted to use this software or any of the associated files
+// as sample data for the purposes of building machine learning models.
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include <singleapplication.h>
+#include "messagereceiver.h"
+
+int main(int argc, char *argv[])
+{
+    QCoreApplication app( argc, argv );
+
+    // Separate single instance object (that allows secondary instances)
+    SingleApplication single_instance_guard( argc, argv, true );
+
+    MessageReceiver msgReceiver;
+
+    // If this is a secondary instance
+    if( single_instance_guard.isSecondary() ) {
+        single_instance_guard.sendMessage( app.arguments().join(' ').toUtf8() );
+        qDebug() << "App already running.";
+        qDebug() << "Primary instance PID: " << single_instance_guard.primaryPid();
+        qDebug() << "Primary instance user: " << single_instance_guard.primaryUser();
+        return 0;
+    } else {
+        QObject::connect(
+            &single_instance_guard,
+            &SingleApplication::receivedMessage,
+            &msgReceiver,
+            &MessageReceiver::receivedMessage
+        );
+    }
+
+    return app.exec();
+}

--- a/examples/separate_object/messagereceiver.cpp
+++ b/examples/separate_object/messagereceiver.cpp
@@ -1,0 +1,35 @@
+// Copyright (c) Itay Grudev 2015 - 2023
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// Permission is not granted to use this software or any of the associated files
+// as sample data for the purposes of building machine learning models.
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#include <QDebug>
+#include "messagereceiver.h"
+
+MessageReceiver::MessageReceiver(QObject *parent) : QObject(parent)
+{
+}
+
+void MessageReceiver::receivedMessage(int instanceId, QByteArray message)
+{
+    qDebug() << "Received message from instance: " << instanceId;
+    qDebug() << "Message Text: " << message;
+}

--- a/examples/separate_object/messagereceiver.h
+++ b/examples/separate_object/messagereceiver.h
@@ -1,0 +1,38 @@
+// Copyright (c) Itay Grudev 2015 - 2023
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// Permission is not granted to use this software or any of the associated files
+// as sample data for the purposes of building machine learning models.
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#ifndef MESSAGERECEIVER_H
+#define MESSAGERECEIVER_H
+
+#include <QObject>
+
+class MessageReceiver : public QObject
+{
+    Q_OBJECT
+public:
+    explicit MessageReceiver(QObject *parent = 0);
+public slots:
+    void receivedMessage( int instanceId, QByteArray message );
+};
+
+#endif // MESSAGERECEIVER_H

--- a/examples/separate_object/separate_object.pro
+++ b/examples/separate_object/separate_object.pro
@@ -1,0 +1,9 @@
+# Single Application implementation
+include(../../singleapplication.pri)
+DEFINES += QAPPLICATION_CLASS=FreeStandingSingleApplication
+
+SOURCES += main.cpp \
+    messagereceiver.cpp
+
+HEADERS += \
+    messagereceiver.h

--- a/singleapplication_p.cpp
+++ b/singleapplication_p.cpp
@@ -140,33 +140,33 @@ void SingleApplicationPrivate::genBlockServerName()
 #if QT_VERSION < QT_VERSION_CHECK(6, 3, 0)
     appData.addData( "SingleApplication", 17 );
 #else
-    appData.addData( QByteArrayView{"SingleApplication"} );    
+    appData.addData( QByteArrayView{"SingleApplication"} );
 #endif
-    appData.addData( SingleApplication::app_t::applicationName().toUtf8() );
-    appData.addData( SingleApplication::app_t::organizationName().toUtf8() );
-    appData.addData( SingleApplication::app_t::organizationDomain().toUtf8() );
+    appData.addData( QCoreApplication::applicationName().toUtf8() );
+    appData.addData( QCoreApplication::organizationName().toUtf8() );
+    appData.addData( QCoreApplication::organizationDomain().toUtf8() );
 
     if ( ! appDataList.isEmpty() )
         appData.addData( appDataList.join(QString()).toUtf8() );
 
     if( ! (options & SingleApplication::Mode::ExcludeAppVersion) ){
-        appData.addData( SingleApplication::app_t::applicationVersion().toUtf8() );
+        appData.addData( QCoreApplication::applicationVersion().toUtf8() );
     }
 
     if( ! (options & SingleApplication::Mode::ExcludeAppPath) ){
 #if defined(Q_OS_WIN)
-        appData.addData( SingleApplication::app_t::applicationFilePath().toLower().toUtf8() );
+        appData.addData( QCoreApplication::applicationFilePath().toLower().toUtf8() );
 #elif defined(Q_OS_LINUX)
         // If the application is running as an AppImage then the APPIMAGE env var should be used
         // instead of applicationPath() as each instance is launched with its own executable path
         const QByteArray appImagePath = qgetenv( "APPIMAGE" );
         if( appImagePath.isEmpty() ){ // Not running as AppImage: use path to executable file
-            appData.addData( SingleApplication::app_t::applicationFilePath().toUtf8() );
+            appData.addData( QCoreApplication::applicationFilePath().toUtf8() );
         } else { // Running as AppImage: Use absolute path to AppImage file
             appData.addData( appImagePath );
         };
 #else
-        appData.addData( SingleApplication::app_t::applicationFilePath().toUtf8() );
+        appData.addData( QCoreApplication::applicationFilePath().toUtf8() );
 #endif
     }
 


### PR DESCRIPTION
This is a pure extension and fully backwards compatible. (Unless I made a mistake. 😉)

I have two requirements for the library that are not currently possible:

1. I want to use it as a pre-compiled library while still being able to choose my `QXxxApplication` class at build time.
2. I need to be able to decide at runtime whether to use the single instance stuff (without starting a server and so on).

This PR allows both by making the `SingleApplication` class an object that is not derived from `QXxxApplication`. On the user side, you need to instantiate a separate `SingleApplication` object after your `QXxxApplication` object. I've added a new example `separate_object` which mirrors `sending_arguments` but uses `SingleApplication` as a separate object.

Of course, the better approach would be to put the implementation into a separate class with an appropriate name and then use that to implement `SingleApplication` as it currently is. I would be delighted if this were implemented for 4.x. Then you could also use the functionality with installed CMake Config and not just as a Git submodule.

If you are willing to merge this, I would also create a PR with CMake install for CMake Config files in “FreeStanding” mode.

If you don't want to merge this, but are willing to merge the “better approach” mentioned, then I can also implement a corresponding PR for 3.x.

@itay-grudev What do you think?