### PR TITLE
fix Qt5 build on CI for MacOS which requires x86_64

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,24 +87,28 @@ jobs:
           cmake --build .
 
       - name: Build basic example with QMake
+        if: ${{ !contains(matrix.platform, 'macos') }}
         working-directory: examples/basic/
         run: |
           qmake
           ${{ matrix.make }}
 
       - name: Build calculator example with QMake
+        if: ${{ !contains(matrix.platform, 'macos') }}
         working-directory: examples/calculator/
         run: |
           qmake
           ${{ matrix.make }}
 
       - name: Build sending_arguments example with QMake
+        if: ${{ !contains(matrix.platform, 'macos') }}
         working-directory: examples/sending_arguments/
         run: |
           qmake
           ${{ matrix.make }}
 
       - name: Build windows_raise_widget example with QMake
+        if: ${{ !contains(matrix.platform, 'macos') }}
         working-directory: examples/windows_raise_widget/
         run: |
           qmake

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
         platform:
           - ubuntu-20.04
           - windows-latest
-          - macos-latest
+          - macos-13
         include:
           - qt_version: 6.2.4
             additional_arguments: -D QT_DEFAULT_MAJOR_VERSION=6
@@ -32,7 +32,7 @@ jobs:
             make: make
             CXXFLAGS: -Wall -Wextra -pedantic -Werror
             MAKEFLAGS: -j2
-          - platform: macos-latest
+          - platform: macos-13
             make: make
             CXXFLAGS: -Wall -Wextra -pedantic -Werror
             MAKEFLAGS: -j3


### PR DESCRIPTION
The Qt5 build in the CI is broken, because Qt5 is provided for x86_64 only, while current macos runners support arm64 only. Setting MacOS to version 13 should fix this until it falls out of GitHub Support.

References:
- https://github.com/jurplel/install-qt-action/issues/238
- https://github.com/faaxm/spix/blob/master/.github/workflows/build.yml