### PR TITLE
fix: missing header file

### DIFF
--- a/singleapplication.cpp
+++ b/singleapplication.cpp
@@ -21,6 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+#include <QtCore/QDebug>
 #include <QtCore/QElapsedTimer>
 #include <QtCore/QByteArray>
 #include <QtCore/QSharedMemory>

--- a/singleapplication_p.h
+++ b/singleapplication_p.h
@@ -33,6 +33,7 @@
 #ifndef SINGLEAPPLICATION_P_H
 #define SINGLEAPPLICATION_P_H
 
+#include <QtCore/QMap>
 #include <QtCore/QSharedMemory>
 #include <QtNetwork/QLocalServer>
 #include <QtNetwork/QLocalSocket>


### PR DESCRIPTION
like:
```
error: implicit instantiation of undefined template 'QMap<QLocalSocket *, ConnectionInfo>'
  101 |     QMap<QLocalSocket*, ConnectionInfo> connectionMap;
```