### PR TITLE
Fix QSharedMemory on macOS with Qt 6.6+

### DIFF
--- a/singleapplication.cpp
+++ b/singleapplication.cpp
@@ -69,7 +69,9 @@ SingleApplication::SingleApplication( int &argc, char *argv[], bool allowSeconda
     // By explicitly attaching it and then deleting it we make sure that the
     // memory is deleted even after the process has crashed on Unix.
 #if QT_VERSION >= QT_VERSION_CHECK(6, 6, 0)
-    d->memory = new QSharedMemory( QNativeIpcKey( d->blockServerName ) );
+    //d->memory = new QSharedMemory( QNativeIpcKey( d->blockServerName ) ); //old implementation
+    // Use legacy (System V) key type as POSIX realtime shm may not work on macOS
+    d->memory = new QSharedMemory( QSharedMemory::legacyNativeKey( d->blockServerName ) );
 #else
     d->memory = new QSharedMemory( d->blockServerName );
 #endif
@@ -78,7 +80,9 @@ SingleApplication::SingleApplication( int &argc, char *argv[], bool allowSeconda
 #endif
     // Guarantee thread safe behaviour with a shared memory block.
 #if QT_VERSION >= QT_VERSION_CHECK(6, 6, 0)
-    d->memory = new QSharedMemory( QNativeIpcKey( d->blockServerName ) );
+    //d->memory = new QSharedMemory( QNativeIpcKey( d->blockServerName ) ); //old implementation
+    // Use legacy (System V) key type as POSIX realtime shm may not work on macOS
+    d->memory = new QSharedMemory( QSharedMemory::legacyNativeKey( d->blockServerName ) );
 #else
     d->memory = new QSharedMemory( d->blockServerName );
 #endif


### PR DESCRIPTION
Qt 6.6+ defaults to POSIX Realtime shared memory via QNativeIpcKey on macOS. However, POSIX shared memory (shm_open) requires Qt to be built with -feature-ipc_posix and has strict naming requirements.

Many Qt installations (including Homebrew) don't have POSIX IPC enabled, causing the error:
  QSharedMemory::KeyError "QSharedMemory::attach (shm_open): bad name"

Use legacyNativeKey() to force System V shared memory, which works reliably on all macOS configurations regardless of Qt build options.

Fixes single instance detection failing on macOS with Qt 6.6+.