### PR TITLE
Fix: switched runner image versions to latest

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,11 +28,11 @@ jobs:
             additional_arguments: -D QT_DEFAULT_MAJOR_VERSION=6
           - qt_version: 6.5.0
             additional_arguments: -D QT_DEFAULT_MAJOR_VERSION=6
-          - platform: ubuntu-20.04
+          - platform: ubuntu-latest
             make: make
             CXXFLAGS: -Wall -Wextra -pedantic -Werror
             MAKEFLAGS: -j2
-          - platform: macos-13
+          - platform: macos-15-intel
             make: make
             CXXFLAGS: -Wall -Wextra -pedantic -Werror
             MAKEFLAGS: -j3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
         platform:
           - ubuntu-latest
           - windows-latest
-          - macos-latest
+          - macos-15
         include:
           - qt_version: 6.2.4
             additional_arguments: -D QT_DEFAULT_MAJOR_VERSION=6

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,9 +20,9 @@ jobs:
           - 6.2.4
           - 6.5.0
         platform:
-          - ubuntu-20.04
+          - ubuntu-latest
           - windows-latest
-          - macos-13
+          - macos-latest
         include:
           - qt_version: 6.2.4
             additional_arguments: -D QT_DEFAULT_MAJOR_VERSION=6

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
         platform:
           - ubuntu-latest
           - windows-latest
-          - macos-15
+          - macos-15-intel
         include:
           - qt_version: 6.2.4
             additional_arguments: -D QT_DEFAULT_MAJOR_VERSION=6


### PR DESCRIPTION
Because macos-13 is deprecated and Ubuntu 20.04 is EOL jobs can't run on GitHub Actions. This change keeps all the GitHub action platforms to latest to avoid this issue in the future. The Macos 15 is an exception, since it's the last GitHub Runner image that supports `x86_64`.

I need to understand what's the issue there and add support for it, but that's a separate problem.