### PR TITLE
Verify primary PID is still alive before assuming it is running

### DIFF
--- a/singleapplication.cpp
+++ b/singleapplication.cpp
@@ -26,8 +26,35 @@
 #include <QtCore/QByteArray>
 #include <QtCore/QSharedMemory>
 
+#ifdef Q_OS_UNIX
+#include <signal.h>
+#include <errno.h>
+#endif
+#ifdef Q_OS_WIN
+#include <windows.h>
+#endif
+
 #include "singleapplication.h"
 #include "singleapplication_p.h"
+
+static bool isProcessRunning( qint64 pid )
+{
+    if ( pid <= 0 )
+        return false;
+
+#ifdef Q_OS_UNIX
+    return kill( static_cast<pid_t>( pid ), 0 ) == 0 || errno != ESRCH;
+#endif
+#ifdef Q_OS_WIN
+    HANDLE hProcess = OpenProcess( PROCESS_QUERY_LIMITED_INFORMATION, FALSE, static_cast<DWORD>( pid ) );
+    if ( hProcess == NULL )
+        return false;
+    DWORD exitCode;
+    bool running = GetExitCodeProcess( hProcess, &exitCode ) && exitCode == STILL_ACTIVE;
+    CloseHandle( hProcess );
+    return running;
+#endif
+}
 
 /**
  * @brief Constructor. Checks and fires up LocalServer or closes the program
@@ -136,6 +163,13 @@ SingleApplication::SingleApplication( int &argc, char *argv[], bool allowSeconda
         qCritical() << "SingleApplication: Unable to lock memory after random wait.";
         abortSafely();
       }
+    }
+
+    // If the recorded primary PID is no longer running (e.g. force-killed),
+    // take over as the primary instance
+    if( inst->primary && !isProcessRunning( inst->primaryPid ) ){
+        qWarning() << "SingleApplication: Primary instance (PID" << inst->primaryPid << ") is no longer running. Taking over.";
+        d->initializeMemoryBlock();
     }
 
     if( inst->primary == false ){


### PR DESCRIPTION
When a primary instance is force-killed (SIGKILL), the shared memory block persists on Unix systems with `primary=true` and the stale PID. Currently this causes all subsequent launches to detect a non-existent primary and immediately exit as secondary instances.

This PR adds an `isProcessRunning()` check after the shared memory checksum verification. If the recorded `primaryPid` no longer corresponds to a running process:

- **Unix**: uses `kill(pid, 0)` + `errno != ESRCH`
- **Windows**: uses `OpenProcess()` + `GetExitCodeProcess()`

The new instance then takes over as primary instead of exiting.

Tested on macOS (force-kill scenario) and confirmed the stale PID warning is now followed by successful takeover.