### PR TITLE
fix: clamp negative msecs to -1 for waitForReadyRead()

### DIFF
--- a/singleapplication_p.cpp
+++ b/singleapplication_p.cpp
@@ -321,7 +321,8 @@ bool SingleApplicationPrivate::writeConfirmedFrame( int msecs, const QByteArray 
     socket->write( msg );
     socket->flush();
 
-    bool result = socket->waitForReadyRead( msecs ); // await ack byte
+    // Clamp negative msecs to -1 (Qt6's "wait forever" sentinel for waitForReadyRead)
+    bool result = socket->waitForReadyRead( msecs < 0 ? -1 : msecs ); // await ack byte
     if (result) {
         socket->read( 1 );
         return true;


### PR DESCRIPTION
## Summary
- Fix `waitForReadyRead()` silently failing when msecs is negative

## Problem
`QAbstractSocket::waitForReadyRead(int msecs)` treats any negative value as
an error and returns `false` immediately. However, Qt6 defines `-1` as the
"wait forever" sentinel.

In `writeConfirmedFrame()`, `msecs` is computed as
`(timeout - elapsed)`, which can become negative when elapsed exceeds the
original timeout. This causes `sendMessage()` to silently fail.

## Fix
Clamp negative msecs to `-1`, which is the correct Qt6 "wait forever" value.
This preserves the original intent: when the timeout budget is exhausted,
block until data arrives rather than failing immediately.

## Test Plan
- [x] Logic verified: negative msecs now clamped to Qt6's -1 sentinel
- [x] Original issue reporter's fix confirmed as correct approach
- [x] No change to the positive msecs path

Fixes #194
